### PR TITLE
feat: add version control status colors

### DIFF
--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -224,6 +224,13 @@ function M._theme_colors(pal, spec)
     ["terminal.ansi.dim_white"] = pal.white.dim,
 
     ["link_text.hover"] = pal.cyan.base,
+
+    ["version_control.added"] = spec.git.add,
+    ["version_control.deleted"] = spec.git.removed,
+    ["version_control.modified"] = spec.git.changed,
+    ["version_control.renamed"] = spec.git.changed,
+    ["version_control.conflict"] = spec.git.conflict,
+    ["version_control.ignored"] = spec.git.ignored,
   }
 end
 


### PR DESCRIPTION
Add adopting theme colors for version control status indicators to support git integration. 
See also https://zed.dev/blog/git

|State|Screenshot (Terafox theme as example)|
|---|---|
|Before|<img width="653" alt="before" src="https://github.com/user-attachments/assets/c35b0c0c-82ff-4640-b4b4-9d11264cf17c" />|
|After|<img width="656" alt="after" src="https://github.com/user-attachments/assets/ee5b14d5-1a19-41b3-a9d7-8e5163a4688b" />|