### PR TITLE
fix(theme): resolve scrollbar appearance

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "nvim-nightfox"
 name = "Nightfox (Neovim) Themes"
-version = "0.4.0"
+version = "0.4.1"
 schema_version = 1
 authors = ["Christian Angermann"]
 description = "A port of the Neovim Nightfox themes"

--- a/lib/nightfox-zed.rockspec
+++ b/lib/nightfox-zed.rockspec
@@ -1,5 +1,5 @@
 package = "nvim-nightfox"
-version = "0.4.0-1"
+version = "0.4.1-1"
 description = {
   summary = "A port of the Neovim Nightfox themes",
   detailed = [[

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -1,7 +1,7 @@
 ---@class ZedTheme
 ---@field private _ns string Namespace
 ---@field private _neovim_polyfill function
----@field private _with_alpha function
+---@field private _alpha function
 local M = {}
 M._ns = ""
 
@@ -101,7 +101,7 @@ function M._player_colors(spec)
     {
       cursor = spec.fg0,
       background = spec.bg3,
-      selection = M._with_alpha(spec.sel0, 0.5),
+      selection = M._alpha(spec.sel0, 0.5),
     },
   }
 end
@@ -127,17 +127,17 @@ function M._theme_colors(pal, spec)
     background = spec.bg0,
 
     ["element.background"] = spec.sel0,
-    ["element.hover"] = M._with_alpha(spec.sel0, 0.25),
+    ["element.hover"] = M._alpha(spec.sel0, 0.25),
     ["element.active"] = spec.sel0,
-    ["element.selected"] = M._with_alpha(spec.sel0, 0.75),
+    ["element.selected"] = M._alpha(spec.sel0, 0.75),
     ["element.disabled"] = AS_NONE,
 
     ["drop_target.background"] = spec.bg0,
 
     ["ghost_element.background"] = AS_NONE,
-    ["ghost_element.hover"] = M._with_alpha(spec.sel1, 0.25),
-    ["ghost_element.active"] = spec.sel1,                        -- usage: UI popout trigger
-    ["ghost_element.selected"] = M._with_alpha(spec.sel1, 0.75), -- usage: UI popout item
+    ["ghost_element.hover"] = M._alpha(spec.sel1, 0.25),
+    ["ghost_element.active"] = spec.sel1, -- usage: UI popout trigger
+    ["ghost_element.selected"] = M._alpha(spec.sel1, 0.75), -- usage: UI popout item
     ["ghost_element.disabled"] = AS_NONE,
 
     text = spec.fg0,
@@ -416,7 +416,7 @@ end
 ---@param hex_color string
 ---@param percent number Alpha channel number between 0 and 1
 ---@return string Hexadecimal color with alpha channel
-function M._with_alpha(hex_color, percent)
+function M._alpha(hex_color, percent)
   if percent < 0 or percent > 1 then
     error(string.format("[%s] Invalid value! Expected: between 0 and 1. Received: %s", M._ns, percent))
   end

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -168,11 +168,11 @@ function M._theme_colors(pal, spec)
     ["panel.indent_guide_hover"] = AS_NONE,
     ["pane.focused_border"] = AS_NONE,
     ["pane.group_border"] = AS_NONE,
-    ["scrollbar.thumb.background"] = pal.black.dim,
-    ["scrollbar.thumb.hover_background"] = pal.black.bright,
-    ["scrollbar.thumb.border"] = pal.black.dim,
-    ["scrollbar.track.background"] = spec.bg1,
-    ["scrollbar.track.border"] = spec.bg0,
+    ["scrollbar.thumb.background"] = M._alpha(spec.sel1, 0.75),
+    ["scrollbar.thumb.hover_background"] = spec.sel1,
+    ["scrollbar.thumb.border"] = nil,
+    ["scrollbar.track.background"] = M._alpha(spec.sel0, 0.25),
+    ["scrollbar.track.border"] = nil,
 
     -- Editor
     ["editor.foreground"] = spec.fg1,

--- a/themes/nvim-nightfox.json
+++ b/themes/nvim-nightfox.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "appearance": "dark",
-      "name": "Nightfox (dev)",
+      "name": "Nightfox",
       "style": {
         "accents": [
           "#6085b6",
@@ -67,11 +67,9 @@
         ],
         "predictive": "#71839b",
         "renamed": "#dbc074",
-        "scrollbar.thumb.background": "#30323a",
-        "scrollbar.thumb.border": "#30323a",
-        "scrollbar.thumb.hover_background": "#575860",
-        "scrollbar.track.background": "#192330",
-        "scrollbar.track.border": "#131a24",
+        "scrollbar.thumb.background": "#3c5372BF",
+        "scrollbar.thumb.hover_background": "#3c5372",
+        "scrollbar.track.background": "#2b3b513F",
         "search.match_background": "#3c5372",
         "status_bar.background": "#131a24",
         "success": "#81b29a",
@@ -207,7 +205,7 @@
     },
     {
       "appearance": "light",
-      "name": "Dayfox (dev)",
+      "name": "Dayfox",
       "style": {
         "accents": [
           "#223d90",
@@ -269,11 +267,9 @@
         ],
         "predictive": "#824d5b",
         "renamed": "#ac5402",
-        "scrollbar.thumb.background": "#2d251f",
-        "scrollbar.thumb.border": "#2d251f",
-        "scrollbar.thumb.hover_background": "#534c45",
-        "scrollbar.track.background": "#f6f2ee",
-        "scrollbar.track.border": "#e4dcd4",
+        "scrollbar.thumb.background": "#a4c1c2BF",
+        "scrollbar.thumb.hover_background": "#a4c1c2",
+        "scrollbar.track.background": "#e7d2be3F",
         "search.match_background": "#a4c1c2",
         "status_bar.background": "#e4dcd4",
         "success": "#396847",
@@ -409,7 +405,7 @@
     },
     {
       "appearance": "light",
-      "name": "Dawnfox (dev)",
+      "name": "Dawnfox",
       "style": {
         "accents": [
           "#295e73",
@@ -471,11 +467,9 @@
         ],
         "predictive": "#a8a3b3",
         "renamed": "#ea9d34",
-        "scrollbar.thumb.background": "#504c6b",
-        "scrollbar.thumb.border": "#504c6b",
-        "scrollbar.thumb.hover_background": "#5f5695",
-        "scrollbar.track.background": "#faf4ed",
-        "scrollbar.track.border": "#ebe5df",
+        "scrollbar.thumb.background": "#b8ceceBF",
+        "scrollbar.thumb.hover_background": "#b8cece",
+        "scrollbar.track.background": "#d0d8d83F",
         "search.match_background": "#b8cece",
         "status_bar.background": "#ebe5df",
         "success": "#618774",
@@ -611,7 +605,7 @@
     },
     {
       "appearance": "dark",
-      "name": "Duskfox (dev)",
+      "name": "Duskfox",
       "style": {
         "accents": [
           "#4a869c",
@@ -673,11 +667,9 @@
         ],
         "predictive": "#6e6a86",
         "renamed": "#f6c177",
-        "scrollbar.thumb.background": "#322e42",
-        "scrollbar.thumb.border": "#322e42",
-        "scrollbar.thumb.hover_background": "#47407d",
-        "scrollbar.track.background": "#232136",
-        "scrollbar.track.border": "#191726",
+        "scrollbar.thumb.background": "#63577dBF",
+        "scrollbar.thumb.hover_background": "#63577d",
+        "scrollbar.track.background": "#433c593F",
         "search.match_background": "#63577d",
         "status_bar.background": "#191726",
         "success": "#a3be8c",
@@ -813,7 +805,7 @@
     },
     {
       "appearance": "dark",
-      "name": "Nordfox (dev)",
+      "name": "Nordfox",
       "style": {
         "accents": [
           "#668aab",
@@ -875,11 +867,9 @@
         ],
         "predictive": "#7e8188",
         "renamed": "#ebcb8b",
-        "scrollbar.thumb.background": "#353a45",
-        "scrollbar.thumb.border": "#353a45",
-        "scrollbar.thumb.hover_background": "#465780",
-        "scrollbar.track.background": "#2e3440",
-        "scrollbar.track.border": "#232831",
+        "scrollbar.thumb.background": "#4f6074BF",
+        "scrollbar.thumb.hover_background": "#4f6074",
+        "scrollbar.track.background": "#3e4a5b3F",
         "search.match_background": "#4f6074",
         "status_bar.background": "#232831",
         "success": "#a3be8c",
@@ -1015,7 +1005,7 @@
     },
     {
       "appearance": "dark",
-      "name": "Terafox (dev)",
+      "name": "Terafox",
       "style": {
         "accents": [
           "#4d7d90",
@@ -1077,11 +1067,9 @@
         ],
         "predictive": "#587b7b",
         "renamed": "#fda47f",
-        "scrollbar.thumb.background": "#282a30",
-        "scrollbar.thumb.border": "#282a30",
-        "scrollbar.thumb.hover_background": "#4e5157",
-        "scrollbar.track.background": "#152528",
-        "scrollbar.track.border": "#0f1c1e",
+        "scrollbar.thumb.background": "#425e5eBF",
+        "scrollbar.thumb.hover_background": "#425e5e",
+        "scrollbar.track.background": "#293e403F",
         "search.match_background": "#425e5e",
         "status_bar.background": "#0f1c1e",
         "success": "#7aa4a1",
@@ -1217,7 +1205,7 @@
     },
     {
       "appearance": "dark",
-      "name": "Carbonfox (dev)",
+      "name": "Carbonfox",
       "style": {
         "accents": [
           "#6690d9",
@@ -1279,11 +1267,9 @@
         ],
         "predictive": "#7b7c7e",
         "renamed": "#08bdba",
-        "scrollbar.thumb.background": "#222222",
-        "scrollbar.thumb.border": "#222222",
-        "scrollbar.thumb.hover_background": "#484848",
-        "scrollbar.track.background": "#161616",
-        "scrollbar.track.border": "#0c0c0c",
+        "scrollbar.thumb.background": "#525253BF",
+        "scrollbar.thumb.hover_background": "#525253",
+        "scrollbar.track.background": "#2a2a2a3F",
         "search.match_background": "#525253",
         "status_bar.background": "#0c0c0c",
         "success": "#25be6a",


### PR DESCRIPTION
This improves consistency with the overall theme by replacing solid scrollbar colors with semi-transparent variants

See some example:

| Before | After |
|---|---|
|<img width="808" alt="b_night" src="https://github.com/user-attachments/assets/8cf4fd12-a041-45a4-99b7-babde6e64e79" />|<img width="808" alt="a_night" src="https://github.com/user-attachments/assets/41ece782-c782-405a-8a9e-977e7df22c80" />|
|<img width="808" alt="b_day" src="https://github.com/user-attachments/assets/71e99e02-9449-4c7f-b16a-a2cad31cb785" />|<img width="808" alt="a_day" src="https://github.com/user-attachments/assets/e2415fea-1636-40a7-a117-16b85c62a4c4" />|
|<img width="808" alt="b_dusk" src="https://github.com/user-attachments/assets/ed8e8e60-99b6-4262-b44d-123946d58daa" />|<img width="808" alt="a_dusk" src="https://github.com/user-attachments/assets/1bd1f89c-bb72-45c6-995d-af3f5273acbc" />|
|<img width="808" alt="b_tera" src="https://github.com/user-attachments/assets/0587fb08-f5e3-4386-8d32-5e8cc180eff1" />|<img width="808" alt="a_tera" src="https://github.com/user-attachments/assets/a3e2364a-b458-41c8-a810-3976bfdb42b3" />|











- closes #23