### PR TITLE
feat: introduce blurred theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,35 @@
 
 ## Available Themes
 
+All themes are available in both **opaque** and **blurred** variants.
+
 ### Nightfox
 
-![nightfox](https://github.com/cange/nightfox.zed/assets/28717/85cbf841-11d8-45c9-97f8-cbb5eedaea7b)
+![nightfox](https://github.com/cange/nightfox.zed/assets/28717/c5c979a2-5fb0-4f0c-bbea-3f9ff8b38b8a)
 
 ### Dayfox
 
-![dayfox](https://github.com/cange/nightfox.zed/assets/28717/8816c97c-cc29-489b-9f0b-51ec7b24d661)
+![dayfox](https://github.com/cange/nightfox.zed/assets/28717/0de9ba81-aa20-472b-bdca-91f6d95edfa9)
 
 ### Dawnfox
 
-![dawnfox](https://github.com/cange/nightfox.zed/assets/28717/3b085140-ebbb-4937-b186-851821163060)
+![dawnfox](https://github.com/cange/nightfox.zed/assets/28717/454f34b1-70d8-444e-b028-9dee850f9bda)
 
 ### Duskfox
 
-![duskfox](https://github.com/cange/nightfox.zed/assets/28717/74a47210-ed27-448d-bf1a-9f45e7d62b8d)
+![duskfox](https://github.com/cange/nightfox.zed/assets/28717/c5442cd7-b938-4014-b48d-a2c1e88e28c7)
 
 ### Nordfox
 
-![nordfox](https://github.com/cange/nightfox.zed/assets/28717/19d97482-43db-4724-8560-5aef029044cc)
+![nordfox](https://github.com/cange/nightfox.zed/assets/28717/24816d4c-d2a7-45ef-a332-5f6dee5393fd)
 
 ### Terafox
 
-![terafox](https://github.com/cange/nightfox.zed/assets/28717/a56303b5-f286-442f-9aaf-6307cdfbaa3d)
+![terafox](https://github.com/cange/nightfox.zed/assets/28717/4ef6cb17-843e-48c0-96db-b9566621b894)
 
 ### Carbonfox
 
-![carbonfox](https://github.com/cange/nightfox.zed/assets/28717/8a1c33b1-6fd2-48e2-913c-6930845abdc6)
+![carbonfox](https://github.com/cange/nightfox.zed/assets/28717/34635356-1c52-4d86-9c95-e603e8b1fa42)
 
 > Used font in the screenshots: "JetBrainsMono"
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "nvim-nightfox"
-name = "Nightfox Themes (Neovim)"
-version = "0.4.2"
-schema_version = 1
+name = "Nightfox Themes - opaque / blurred"
+version = "0.5.0"
+scema_version = 2
 authors = ["Christian Angermann"]
-description = "A port of the Neovim Nightfox themes"
+description = "A port of the Neovim Nightfox themes. Includes all variants as opaque and blurred version."
 repository = "https://github.com/cange/nightfox.zed"

--- a/lib/nightfox-zed.rockspec
+++ b/lib/nightfox-zed.rockspec
@@ -1,10 +1,10 @@
 package = "nvim-nightfox"
-version = "0.4.2-1"
+version = "0.5.0-1"
 description = {
-  summary = "A port of the Neovim Nightfox themes",
+  summary = "A port of the Neovim Nightfox themes. Supports opaque and blurred variant",
   detailed = [[
     A complete port of the Neovim Nightfox colorscheme collection for Zed editor.
-    Includes all variants.
+    All themes are available in both opaque and blurred variants.
   ]],
   license = "MIT",
   homepage = "https://github.com/cange/nightfox.zed",

--- a/lib/util.lua
+++ b/lib/util.lua
@@ -3,6 +3,7 @@
 ---@field neovim_polyfill function
 ---@field tbl_merge function
 local M = {}
+M._ns = "util"
 
 ---Provides a color in hexadecimal format with an alpha channel
 ---@param hex_color string
@@ -12,7 +13,7 @@ local function alpha(hex_color, percent)
   if percent < 0 or percent > 1 then
     error(string.format("[%s] Invalid value! Expected: between 0 and 1. Received: %s", M._ns, percent))
   end
-  local alpha_value = math.floor(percent * 255)
+  local alpha_value = math.floor(percent * 255 + 0.5) -- 255 + 0.5 Round to nearest integer for 8-bit alpha value
   return hex_color .. string.format("%02X", alpha_value)
 end
 

--- a/themes/nvim-nightfox.json
+++ b/themes/nvim-nightfox.json
@@ -1,54 +1,55 @@
 {
   "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
   "author": "Christian Angermann",
-  "name": "Nightfox Themes (Neovim)",
+  "name": "Nightfox Themes - opaque / blurred",
   "themes": [
     {
       "appearance": "dark",
-      "name": "Nightfox",
+      "name": "Nightfox - opaque",
       "style": {
         "accents": [
-          "#6085b6",
-          "#cf8a52",
-          "#8567b6",
-          "#54aeb0",
-          "#ab435d",
-          "#6e9783",
-          "#baa363"
+          "#86abdc80",
+          "#f6b07980",
+          "#baa1e280",
+          "#7ad5d680",
+          "#d1698380",
+          "#8ebaa480",
+          "#e0c98980"
         ],
-        "background": "#2b3b51",
-        "border": "#212e3f",
+        "background": "#192330FF",
+        "background.appearance": "opaque",
+        "border": "#212e3fCC",
         "border.disabled": "#192330",
         "border.focused": "#2b3b51",
         "border.selected": "#3c5372",
-        "border.transparent": "#192330",
+        "border.transparent": "#192330FF",
         "border.variant": "#39506d",
         "conflict": "#f4a261",
         "created": "#81b29a",
         "deleted": "#2f2837",
-        "drop_target.background": "#131a24",
-        "editor.active_line.background": "#212e3f",
+        "drop_target.background": "#131a24FF",
+        "editor.active_line.background": "#2b3b514D",
         "editor.active_line_number": "#dbc074",
-        "editor.active_wrap_guide": "#212e3f",
-        "editor.background": "#192330",
-        "editor.document_highlight.bracket_background": "#2b3b51",
+        "editor.active_wrap_guide": "#212e3fFF",
+        "editor.background": "#192330FF",
+        "editor.document_highlight.bracket_background": "#2b3b51FF",
         "editor.foreground": "#cdcecf",
-        "editor.gutter.background": "#192330",
-        "editor.indent_guide": "#212e3f",
-        "editor.indent_guide_active": "#3c5372",
+        "editor.gutter.background": "#192330FF",
+        "editor.indent_guide": "#212e3fFF",
+        "editor.indent_guide_active": "#3c5372FF",
         "editor.line_number": "#71839b",
-        "editor.wrap_guide": "#212e3f",
+        "editor.wrap_guide": "#212e3f80",
         "element.active": "#453f3f",
         "element.background": "#3d3837",
         "element.disabled": "#2b3b51",
         "element.hover": "#453c3a",
         "element.selected": "#453f3f",
-        "elevated_surface.background": "#2b3b51",
+        "elevated_surface.background": "#131a24",
         "error": "#c94f6d",
         "error.background": "#3c2c3c",
-        "ghost_element.active": "#3c5372",
-        "ghost_element.hover": "#3c53723F",
-        "ghost_element.selected": "#3c5372BF",
+        "ghost_element.active": "#3c5372FF",
+        "ghost_element.hover": "#3c53724D",
+        "ghost_element.selected": "#3c5372CC",
         "hidden": "#71839b",
         "hint": "#738091",
         "hint.background": "#2e4045",
@@ -57,25 +58,25 @@
         "info.background": "#2b3b51",
         "link_text.hover": "#63cdcf",
         "modified": "#dbc074",
-        "panel.background": "#131a24",
-        "panel.focused_border": "#3c5372",
+        "panel.background": "#131a244D",
+        "panel.focused_border": "#3c5372FF",
         "players": [
           {
-            "background": "#29394f",
+            "background": "#29394f4D",
             "cursor": "#d6d6d7",
-            "selection": "#2b3b517F"
+            "selection": "#3c5372CC"
           }
         ],
         "predictive": "#71839b",
         "renamed": "#dbc074",
-        "scrollbar.thumb.background": "#3c5372BF",
-        "scrollbar.thumb.hover_background": "#3c5372",
-        "scrollbar.track.background": "#2b3b513F",
-        "search.match_background": "#3c5372",
-        "status_bar.background": "#131a24",
+        "scrollbar.thumb.background": "#3c5372CC",
+        "scrollbar.thumb.hover_background": "#3c5372FF",
+        "scrollbar.track.background": "#2b3b514D",
+        "search.match_background": "#3c5372FF",
+        "status_bar.background": "#131a24FF",
         "success": "#81b29a",
         "success.background": "#2e4045",
-        "surface.background": "#131a24",
+        "surface.background": "#131a24FF",
         "syntax": {
           "boolean": {
             "color": "#f6b079"
@@ -156,9 +157,9 @@
             "color": "#c94f6d"
           }
         },
-        "tab.active_background": "#192330",
-        "tab.inactive_background": "#131a24",
-        "tab_bar.background": "#131a24",
+        "tab.active_background": "#2b3b5180",
+        "tab.inactive_background": "#19233080",
+        "tab_bar.background": "#19233080",
         "terminal.ansi.black": "#393b44",
         "terminal.ansi.blue": "#719cd6",
         "terminal.ansi.bright_black": "#575860",
@@ -183,7 +184,7 @@
         "terminal.ansi.red": "#c94f6d",
         "terminal.ansi.white": "#dfdfe0",
         "terminal.ansi.yellow": "#dbc074",
-        "terminal.background": "#192330",
+        "terminal.background": "#192330FF",
         "terminal.bright_foreground": "#d6d6d7",
         "terminal.dim_foreground": "#aeafb0",
         "terminal.foreground": "#cdcecf",
@@ -192,8 +193,8 @@
         "text.disabled": "#738091",
         "text.muted": "#cdcecf",
         "text.placeholder": "#71839b",
-        "title_bar.background": "#131a24",
-        "toolbar.background": "#192330",
+        "title_bar.background": "#131a24FF",
+        "toolbar.background": "#2b3b5180",
         "version_control.added": "#81b29a",
         "version_control.conflict": "#f4a261",
         "version_control.deleted": "#c94f6d",
@@ -206,50 +207,51 @@
     },
     {
       "appearance": "light",
-      "name": "Dayfox",
+      "name": "Dayfox - opaque",
       "style": {
         "accents": [
-          "#223d90",
-          "#7f5152",
-          "#5e2baf",
-          "#22676d",
-          "#8c1d28",
-          "#30583c",
-          "#924702"
+          "#4863b680",
+          "#a5777980",
+          "#8452d580",
+          "#488d9380",
+          "#b3434e80",
+          "#577f6380",
+          "#b86e2880"
         ],
-        "background": "#e7d2be",
-        "border": "#dbd1dd",
+        "background": "#f6f2eeFF",
+        "background.appearance": "opaque",
+        "border": "#dbd1ddCC",
         "border.disabled": "#f6f2ee",
         "border.focused": "#e7d2be",
         "border.selected": "#a4c1c2",
-        "border.transparent": "#f6f2ee",
+        "border.transparent": "#f6f2eeFF",
         "border.variant": "#aab0ad",
         "conflict": "#955f61",
         "created": "#396847",
         "deleted": "#e6c8c8",
-        "drop_target.background": "#e4dcd4",
-        "editor.active_line.background": "#dbd1dd",
+        "drop_target.background": "#e4dcd4FF",
+        "editor.active_line.background": "#e7d2be4D",
         "editor.active_line_number": "#ac5402",
-        "editor.active_wrap_guide": "#dbd1dd",
-        "editor.background": "#f6f2ee",
-        "editor.document_highlight.bracket_background": "#e7d2be",
+        "editor.active_wrap_guide": "#dbd1ddFF",
+        "editor.background": "#f6f2eeFF",
+        "editor.document_highlight.bracket_background": "#e7d2beFF",
         "editor.foreground": "#3d2b5a",
-        "editor.gutter.background": "#f6f2ee",
-        "editor.indent_guide": "#dbd1dd",
-        "editor.indent_guide_active": "#a4c1c2",
+        "editor.gutter.background": "#f6f2eeFF",
+        "editor.indent_guide": "#dbd1ddFF",
+        "editor.indent_guide_active": "#a4c1c2FF",
         "editor.line_number": "#824d5b",
-        "editor.wrap_guide": "#dbd1dd",
+        "editor.wrap_guide": "#dbd1dd80",
         "element.active": "#e6d9d7",
         "element.background": "#ded2cf",
         "element.disabled": "#e7d2be",
         "element.hover": "#e3d5d2",
         "element.selected": "#e6d9d7",
-        "elevated_surface.background": "#e7d2be",
+        "elevated_surface.background": "#e4dcd4",
         "error": "#a5222f",
         "error.background": "#deb4b5",
-        "ghost_element.active": "#a4c1c2",
-        "ghost_element.hover": "#a4c1c23F",
-        "ghost_element.selected": "#a4c1c2BF",
+        "ghost_element.active": "#a4c1c2FF",
+        "ghost_element.hover": "#a4c1c24D",
+        "ghost_element.selected": "#a4c1c2CC",
         "hidden": "#824d5b",
         "hint": "#837a72",
         "hint.background": "#bdc9bc",
@@ -258,25 +260,25 @@
         "info.background": "#b8bfd9",
         "link_text.hover": "#287980",
         "modified": "#ac5402",
-        "panel.background": "#e4dcd4",
-        "panel.focused_border": "#a4c1c2",
+        "panel.background": "#e4dcd44D",
+        "panel.focused_border": "#a4c1c2FF",
         "players": [
           {
-            "background": "#d3c7bb",
+            "background": "#d3c7bb4D",
             "cursor": "#302b5d",
-            "selection": "#e7d2be7F"
+            "selection": "#a4c1c2CC"
           }
         ],
         "predictive": "#824d5b",
         "renamed": "#ac5402",
-        "scrollbar.thumb.background": "#a4c1c2BF",
-        "scrollbar.thumb.hover_background": "#a4c1c2",
-        "scrollbar.track.background": "#e7d2be3F",
-        "search.match_background": "#a4c1c2",
-        "status_bar.background": "#e4dcd4",
+        "scrollbar.thumb.background": "#a4c1c2CC",
+        "scrollbar.thumb.hover_background": "#a4c1c2FF",
+        "scrollbar.track.background": "#e7d2be4D",
+        "search.match_background": "#a4c1c2FF",
+        "status_bar.background": "#e4dcd4FF",
         "success": "#396847",
         "success.background": "#bdc9bc",
-        "surface.background": "#e4dcd4",
+        "surface.background": "#e4dcd4FF",
         "syntax": {
           "boolean": {
             "color": "#7f5152"
@@ -357,9 +359,9 @@
             "color": "#a5222f"
           }
         },
-        "tab.active_background": "#f6f2ee",
-        "tab.inactive_background": "#e4dcd4",
-        "tab_bar.background": "#e4dcd4",
+        "tab.active_background": "#e7d2be80",
+        "tab.inactive_background": "#f6f2ee80",
+        "tab_bar.background": "#f6f2ee80",
         "terminal.ansi.black": "#352c24",
         "terminal.ansi.blue": "#2848a9",
         "terminal.ansi.bright_black": "#534c45",
@@ -384,7 +386,7 @@
         "terminal.ansi.red": "#a5222f",
         "terminal.ansi.white": "#f2e9e1",
         "terminal.ansi.yellow": "#ac5402",
-        "terminal.background": "#f6f2ee",
+        "terminal.background": "#f6f2eeFF",
         "terminal.bright_foreground": "#302b5d",
         "terminal.dim_foreground": "#643f61",
         "terminal.foreground": "#3d2b5a",
@@ -393,8 +395,8 @@
         "text.disabled": "#837a72",
         "text.muted": "#3d2b5a",
         "text.placeholder": "#824d5b",
-        "title_bar.background": "#e4dcd4",
-        "toolbar.background": "#f6f2ee",
+        "title_bar.background": "#e4dcd4FF",
+        "toolbar.background": "#e7d2be80",
         "version_control.added": "#396847",
         "version_control.conflict": "#955f61",
         "version_control.deleted": "#a5222f",
@@ -407,50 +409,51 @@
     },
     {
       "appearance": "light",
-      "name": "Dawnfox",
+      "name": "Dawnfox - opaque",
       "style": {
         "accents": [
-          "#295e73",
-          "#ca6e69",
-          "#816b9a",
-          "#50848c",
-          "#a5576d",
-          "#597668",
-          "#dd9024"
+          "#2d81a380",
+          "#de8c8880",
+          "#9a80b980",
+          "#5ca7b480",
+          "#c26d8580",
+          "#629f8180",
+          "#eea84680"
         ],
-        "background": "#d0d8d8",
-        "border": "#ebe0df",
+        "background": "#faf4edFF",
+        "background.appearance": "opaque",
+        "border": "#ebe0dfCC",
         "border.disabled": "#faf4ed",
         "border.focused": "#d0d8d8",
         "border.selected": "#b8cece",
-        "border.transparent": "#faf4ed",
+        "border.transparent": "#faf4edFF",
         "border.variant": "#bdbfc9",
         "conflict": "#d7827e",
         "created": "#618774",
         "deleted": "#ecd7d6",
-        "drop_target.background": "#ebe5df",
-        "editor.active_line.background": "#ebe0df",
+        "drop_target.background": "#ebe5dfFF",
+        "editor.active_line.background": "#d0d8d84D",
         "editor.active_line_number": "#ea9d34",
-        "editor.active_wrap_guide": "#ebe0df",
-        "editor.background": "#faf4ed",
-        "editor.document_highlight.bracket_background": "#d0d8d8",
+        "editor.active_wrap_guide": "#ebe0dfFF",
+        "editor.background": "#faf4edFF",
+        "editor.document_highlight.bracket_background": "#d0d8d8FF",
         "editor.foreground": "#575279",
-        "editor.gutter.background": "#faf4ed",
-        "editor.indent_guide": "#ebe0df",
-        "editor.indent_guide_active": "#b8cece",
+        "editor.gutter.background": "#faf4edFF",
+        "editor.indent_guide": "#ebe0dfFF",
+        "editor.indent_guide_active": "#b8ceceFF",
         "editor.line_number": "#a8a3b3",
-        "editor.wrap_guide": "#ebe0df",
+        "editor.wrap_guide": "#ebe0df80",
         "element.active": "#f4dfd9",
         "element.background": "#f0d9d3",
         "element.disabled": "#d0d8d8",
         "element.hover": "#f3ddd7",
         "element.selected": "#f4dfd9",
-        "elevated_surface.background": "#d0d8d8",
+        "elevated_surface.background": "#ebe5df",
         "error": "#b4637a",
         "error.background": "#e5c9cb",
-        "ghost_element.active": "#b8cece",
-        "ghost_element.hover": "#b8cece3F",
-        "ghost_element.selected": "#b8ceceBF",
+        "ghost_element.active": "#b8ceceFF",
+        "ghost_element.hover": "#b8cece4D",
+        "ghost_element.selected": "#b8ceceCC",
         "hidden": "#a8a3b3",
         "hint": "#9893a5",
         "hint.background": "#ccd3c9",
@@ -459,25 +462,25 @@
         "info.background": "#bbcacd",
         "link_text.hover": "#56949f",
         "modified": "#ea9d34",
-        "panel.background": "#ebe5df",
-        "panel.focused_border": "#b8cece",
+        "panel.background": "#ebe5df4D",
+        "panel.focused_border": "#b8ceceFF",
         "players": [
           {
-            "background": "#ebdfe4",
+            "background": "#ebdfe44D",
             "cursor": "#4c4769",
-            "selection": "#d0d8d87F"
+            "selection": "#b8ceceCC"
           }
         ],
         "predictive": "#a8a3b3",
         "renamed": "#ea9d34",
-        "scrollbar.thumb.background": "#b8ceceBF",
-        "scrollbar.thumb.hover_background": "#b8cece",
-        "scrollbar.track.background": "#d0d8d83F",
-        "search.match_background": "#b8cece",
-        "status_bar.background": "#ebe5df",
+        "scrollbar.thumb.background": "#b8ceceCC",
+        "scrollbar.thumb.hover_background": "#b8ceceFF",
+        "scrollbar.track.background": "#d0d8d84D",
+        "search.match_background": "#b8ceceFF",
+        "status_bar.background": "#ebe5dfFF",
         "success": "#618774",
         "success.background": "#ccd3c9",
-        "surface.background": "#ebe5df",
+        "surface.background": "#ebe5dfFF",
         "syntax": {
           "boolean": {
             "color": "#ca6e69"
@@ -558,9 +561,9 @@
             "color": "#b4637a"
           }
         },
-        "tab.active_background": "#faf4ed",
-        "tab.inactive_background": "#ebe5df",
-        "tab_bar.background": "#ebe5df",
+        "tab.active_background": "#d0d8d880",
+        "tab.inactive_background": "#faf4ed80",
+        "tab_bar.background": "#faf4ed80",
         "terminal.ansi.black": "#575279",
         "terminal.ansi.blue": "#286983",
         "terminal.ansi.bright_black": "#5f5695",
@@ -585,7 +588,7 @@
         "terminal.ansi.red": "#b4637a",
         "terminal.ansi.white": "#e5e9f0",
         "terminal.ansi.yellow": "#ea9d34",
-        "terminal.background": "#faf4ed",
+        "terminal.background": "#faf4edFF",
         "terminal.bright_foreground": "#4c4769",
         "terminal.dim_foreground": "#625c87",
         "terminal.foreground": "#575279",
@@ -594,8 +597,8 @@
         "text.disabled": "#9893a5",
         "text.muted": "#575279",
         "text.placeholder": "#a8a3b3",
-        "title_bar.background": "#ebe5df",
-        "toolbar.background": "#faf4ed",
+        "title_bar.background": "#ebe5dfFF",
+        "toolbar.background": "#d0d8d880",
         "version_control.added": "#618774",
         "version_control.conflict": "#d7827e",
         "version_control.deleted": "#b4637a",
@@ -608,50 +611,51 @@
     },
     {
       "appearance": "dark",
-      "name": "Duskfox",
+      "name": "Duskfox - opaque",
       "style": {
         "accents": [
-          "#4a869c",
-          "#d6746f",
-          "#a580d2",
-          "#7bb8c1",
-          "#d84f76",
-          "#8aa872",
-          "#e6a852"
+          "#65b1cd80",
+          "#f0a4a280",
+          "#ccb1ed80",
+          "#a6dae380",
+          "#f083a280",
+          "#b1d19680",
+          "#f9cb8c80"
         ],
-        "background": "#433c59",
-        "border": "#2d2a45",
+        "background": "#232136FF",
+        "background.appearance": "opaque",
+        "border": "#2d2a45CC",
         "border.disabled": "#232136",
         "border.focused": "#433c59",
         "border.selected": "#63577d",
-        "border.transparent": "#232136",
+        "border.transparent": "#232136FF",
         "border.variant": "#4b4673",
         "conflict": "#ea9a97",
         "created": "#a3be8c",
         "deleted": "#4b3148",
-        "drop_target.background": "#191726",
-        "editor.active_line.background": "#2d2a45",
+        "drop_target.background": "#191726FF",
+        "editor.active_line.background": "#433c594D",
         "editor.active_line_number": "#f6c177",
-        "editor.active_wrap_guide": "#2d2a45",
-        "editor.background": "#232136",
-        "editor.document_highlight.bracket_background": "#433c59",
+        "editor.active_wrap_guide": "#2d2a45FF",
+        "editor.background": "#232136FF",
+        "editor.document_highlight.bracket_background": "#433c59FF",
         "editor.foreground": "#e0def4",
-        "editor.gutter.background": "#232136",
-        "editor.indent_guide": "#2d2a45",
-        "editor.indent_guide_active": "#63577d",
+        "editor.gutter.background": "#232136FF",
+        "editor.indent_guide": "#2d2a45FF",
+        "editor.indent_guide_active": "#63577dFF",
         "editor.line_number": "#6e6a86",
-        "editor.wrap_guide": "#2d2a45",
+        "editor.wrap_guide": "#2d2a4580",
         "element.active": "#4c3b4c",
         "element.background": "#473241",
         "element.disabled": "#433c59",
         "element.hover": "#4b3949",
         "element.selected": "#4c3b4c",
-        "elevated_surface.background": "#433c59",
+        "elevated_surface.background": "#191726",
         "error": "#eb6f92",
         "error.background": "#412d44",
-        "ghost_element.active": "#63577d",
-        "ghost_element.hover": "#63577d3F",
-        "ghost_element.selected": "#63577dBF",
+        "ghost_element.active": "#63577dFF",
+        "ghost_element.hover": "#63577d4D",
+        "ghost_element.selected": "#63577dCC",
         "hidden": "#6e6a86",
         "hint": "#817c9c",
         "hint.background": "#363943",
@@ -660,25 +664,25 @@
         "info.background": "#2b344a",
         "link_text.hover": "#9ccfd8",
         "modified": "#f6c177",
-        "panel.background": "#191726",
-        "panel.focused_border": "#63577d",
+        "panel.background": "#1917264D",
+        "panel.focused_border": "#63577dFF",
         "players": [
           {
-            "background": "#373354",
+            "background": "#3733544D",
             "cursor": "#eae8ff",
-            "selection": "#433c597F"
+            "selection": "#63577dCC"
           }
         ],
         "predictive": "#6e6a86",
         "renamed": "#f6c177",
-        "scrollbar.thumb.background": "#63577dBF",
-        "scrollbar.thumb.hover_background": "#63577d",
-        "scrollbar.track.background": "#433c593F",
-        "search.match_background": "#63577d",
-        "status_bar.background": "#191726",
+        "scrollbar.thumb.background": "#63577dCC",
+        "scrollbar.thumb.hover_background": "#63577dFF",
+        "scrollbar.track.background": "#433c594D",
+        "search.match_background": "#63577dFF",
+        "status_bar.background": "#191726FF",
         "success": "#a3be8c",
         "success.background": "#363943",
-        "surface.background": "#191726",
+        "surface.background": "#191726FF",
         "syntax": {
           "boolean": {
             "color": "#f0a4a2"
@@ -759,9 +763,9 @@
             "color": "#eb6f92"
           }
         },
-        "tab.active_background": "#232136",
-        "tab.inactive_background": "#191726",
-        "tab_bar.background": "#191726",
+        "tab.active_background": "#433c5980",
+        "tab.inactive_background": "#23213680",
+        "tab_bar.background": "#23213680",
         "terminal.ansi.black": "#393552",
         "terminal.ansi.blue": "#569fba",
         "terminal.ansi.bright_black": "#47407d",
@@ -786,7 +790,7 @@
         "terminal.ansi.red": "#eb6f92",
         "terminal.ansi.white": "#e0def4",
         "terminal.ansi.yellow": "#f6c177",
-        "terminal.background": "#232136",
+        "terminal.background": "#232136FF",
         "terminal.bright_foreground": "#eae8ff",
         "terminal.dim_foreground": "#cdcbe0",
         "terminal.foreground": "#e0def4",
@@ -795,8 +799,8 @@
         "text.disabled": "#817c9c",
         "text.muted": "#e0def4",
         "text.placeholder": "#6e6a86",
-        "title_bar.background": "#191726",
-        "toolbar.background": "#232136",
+        "title_bar.background": "#191726FF",
+        "toolbar.background": "#433c5980",
         "version_control.added": "#a3be8c",
         "version_control.conflict": "#ea9a97",
         "version_control.deleted": "#eb6f92",
@@ -809,50 +813,51 @@
     },
     {
       "appearance": "dark",
-      "name": "Nordfox",
+      "name": "Nordfox - opaque",
       "style": {
         "accents": [
-          "#668aab",
-          "#b46950",
-          "#9d7495",
-          "#69a7ba",
-          "#a54e56",
-          "#8aa872",
-          "#d9b263"
+          "#8cafd280",
+          "#d8907980",
+          "#c895bf80",
+          "#93ccdc80",
+          "#d06f7980",
+          "#b1d19680",
+          "#f0d39980"
         ],
-        "background": "#3e4a5b",
-        "border": "#39404f",
+        "background": "#2e3440FF",
+        "background.appearance": "opaque",
+        "border": "#39404fCC",
         "border.disabled": "#2e3440",
         "border.focused": "#3e4a5b",
         "border.selected": "#4f6074",
-        "border.transparent": "#2e3440",
+        "border.transparent": "#2e3440FF",
         "border.variant": "#5a657d",
         "conflict": "#c9826b",
         "created": "#a3be8c",
         "deleted": "#403843",
-        "drop_target.background": "#232831",
-        "editor.active_line.background": "#39404f",
+        "drop_target.background": "#232831FF",
+        "editor.active_line.background": "#3e4a5b4D",
         "editor.active_line_number": "#ebcb8b",
-        "editor.active_wrap_guide": "#39404f",
-        "editor.background": "#2e3440",
-        "editor.document_highlight.bracket_background": "#3e4a5b",
+        "editor.active_wrap_guide": "#39404fFF",
+        "editor.background": "#2e3440FF",
+        "editor.document_highlight.bracket_background": "#3e4a5bFF",
         "editor.foreground": "#cdcecf",
-        "editor.gutter.background": "#2e3440",
-        "editor.indent_guide": "#39404f",
-        "editor.indent_guide_active": "#4f6074",
+        "editor.gutter.background": "#2e3440FF",
+        "editor.indent_guide": "#39404fFF",
+        "editor.indent_guide_active": "#4f6074FF",
         "editor.line_number": "#7e8188",
-        "editor.wrap_guide": "#39404f",
+        "editor.wrap_guide": "#39404f80",
         "element.active": "#50464b",
         "element.background": "#493f43",
         "element.disabled": "#3e4a5b",
         "element.hover": "#4d4449",
         "element.selected": "#50464b",
-        "elevated_surface.background": "#3e4a5b",
+        "elevated_surface.background": "#232831",
         "error": "#bf616a",
         "error.background": "#4b3d48",
-        "ghost_element.active": "#4f6074",
-        "ghost_element.hover": "#4f60743F",
-        "ghost_element.selected": "#4f6074BF",
+        "ghost_element.active": "#4f6074FF",
+        "ghost_element.hover": "#4f60744D",
+        "ghost_element.selected": "#4f6074CC",
         "hidden": "#7e8188",
         "hint": "#60728a",
         "hint.background": "#45504f",
@@ -861,25 +866,25 @@
         "info.background": "#3f4a5a",
         "link_text.hover": "#88c0d0",
         "modified": "#ebcb8b",
-        "panel.background": "#232831",
-        "panel.focused_border": "#4f6074",
+        "panel.background": "#2328314D",
+        "panel.focused_border": "#4f6074FF",
         "players": [
           {
-            "background": "#444c5e",
+            "background": "#444c5e4D",
             "cursor": "#c7cdd9",
-            "selection": "#3e4a5b7F"
+            "selection": "#4f6074CC"
           }
         ],
         "predictive": "#7e8188",
         "renamed": "#ebcb8b",
-        "scrollbar.thumb.background": "#4f6074BF",
-        "scrollbar.thumb.hover_background": "#4f6074",
-        "scrollbar.track.background": "#3e4a5b3F",
-        "search.match_background": "#4f6074",
-        "status_bar.background": "#232831",
+        "scrollbar.thumb.background": "#4f6074CC",
+        "scrollbar.thumb.hover_background": "#4f6074FF",
+        "scrollbar.track.background": "#3e4a5b4D",
+        "search.match_background": "#4f6074FF",
+        "status_bar.background": "#232831FF",
         "success": "#a3be8c",
         "success.background": "#45504f",
-        "surface.background": "#232831",
+        "surface.background": "#232831FF",
         "syntax": {
           "boolean": {
             "color": "#d89079"
@@ -960,9 +965,9 @@
             "color": "#bf616a"
           }
         },
-        "tab.active_background": "#2e3440",
-        "tab.inactive_background": "#232831",
-        "tab_bar.background": "#232831",
+        "tab.active_background": "#3e4a5b80",
+        "tab.inactive_background": "#2e344080",
+        "tab_bar.background": "#2e344080",
         "terminal.ansi.black": "#3b4252",
         "terminal.ansi.blue": "#81a1c1",
         "terminal.ansi.bright_black": "#465780",
@@ -987,7 +992,7 @@
         "terminal.ansi.red": "#bf616a",
         "terminal.ansi.white": "#e5e9f0",
         "terminal.ansi.yellow": "#ebcb8b",
-        "terminal.background": "#2e3440",
+        "terminal.background": "#2e3440FF",
         "terminal.bright_foreground": "#c7cdd9",
         "terminal.dim_foreground": "#abb1bb",
         "terminal.foreground": "#cdcecf",
@@ -996,8 +1001,8 @@
         "text.disabled": "#60728a",
         "text.muted": "#cdcecf",
         "text.placeholder": "#7e8188",
-        "title_bar.background": "#232831",
-        "toolbar.background": "#2e3440",
+        "title_bar.background": "#232831FF",
+        "toolbar.background": "#3e4a5b80",
         "version_control.added": "#a3be8c",
         "version_control.conflict": "#c9826b",
         "version_control.deleted": "#bf616a",
@@ -1010,50 +1015,51 @@
     },
     {
       "appearance": "dark",
-      "name": "Terafox",
+      "name": "Terafox - opaque",
       "style": {
         "accents": [
-          "#4d7d90",
-          "#d96f3e",
-          "#934e69",
-          "#89aeb8",
-          "#c54e45",
-          "#688b89",
-          "#d78b6c"
+          "#73a3b780",
+          "#ff966480",
+          "#b9749080",
+          "#afd4de80",
+          "#eb746b80",
+          "#8eb2af80",
+          "#fdb29280"
         ],
-        "background": "#293e40",
-        "border": "#1d3337",
+        "background": "#152528FF",
+        "background.appearance": "opaque",
+        "border": "#1d3337CC",
         "border.disabled": "#152528",
         "border.focused": "#293e40",
         "border.selected": "#425e5e",
-        "border.transparent": "#152528",
+        "border.transparent": "#152528FF",
         "border.variant": "#2d4f56",
         "conflict": "#ff8349",
         "created": "#7aa4a1",
         "deleted": "#4a3332",
-        "drop_target.background": "#0f1c1e",
-        "editor.active_line.background": "#1d3337",
+        "drop_target.background": "#0f1c1eFF",
+        "editor.active_line.background": "#293e404D",
         "editor.active_line_number": "#fda47f",
-        "editor.active_wrap_guide": "#1d3337",
-        "editor.background": "#152528",
-        "editor.document_highlight.bracket_background": "#293e40",
+        "editor.active_wrap_guide": "#1d3337FF",
+        "editor.background": "#152528FF",
+        "editor.document_highlight.bracket_background": "#293e40FF",
         "editor.foreground": "#e6eaea",
-        "editor.gutter.background": "#152528",
-        "editor.indent_guide": "#1d3337",
-        "editor.indent_guide_active": "#425e5e",
+        "editor.gutter.background": "#152528FF",
+        "editor.indent_guide": "#1d3337FF",
+        "editor.indent_guide_active": "#425e5eFF",
         "editor.line_number": "#587b7b",
-        "editor.wrap_guide": "#1d3337",
+        "editor.wrap_guide": "#1d333780",
         "element.active": "#443c34",
         "element.background": "#3c342c",
         "element.disabled": "#293e40",
         "element.hover": "#44382f",
         "element.selected": "#443c34",
-        "elevated_surface.background": "#293e40",
+        "elevated_surface.background": "#0f1c1e",
         "error": "#e85c51",
         "error.background": "#352d2e",
-        "ghost_element.active": "#425e5e",
-        "ghost_element.hover": "#425e5e3F",
-        "ghost_element.selected": "#425e5eBF",
+        "ghost_element.active": "#425e5eFF",
+        "ghost_element.hover": "#425e5e4D",
+        "ghost_element.selected": "#425e5eCC",
         "hidden": "#587b7b",
         "hint": "#6d7f8b",
         "hint.background": "#24383a",
@@ -1062,25 +1068,25 @@
         "info.background": "#1f353c",
         "link_text.hover": "#a1cdd8",
         "modified": "#fda47f",
-        "panel.background": "#0f1c1e",
-        "panel.focused_border": "#425e5e",
+        "panel.background": "#0f1c1e4D",
+        "panel.focused_border": "#425e5eFF",
         "players": [
           {
-            "background": "#254147",
+            "background": "#2541474D",
             "cursor": "#eaeeee",
-            "selection": "#293e407F"
+            "selection": "#425e5eCC"
           }
         ],
         "predictive": "#587b7b",
         "renamed": "#fda47f",
-        "scrollbar.thumb.background": "#425e5eBF",
-        "scrollbar.thumb.hover_background": "#425e5e",
-        "scrollbar.track.background": "#293e403F",
-        "search.match_background": "#425e5e",
-        "status_bar.background": "#0f1c1e",
+        "scrollbar.thumb.background": "#425e5eCC",
+        "scrollbar.thumb.hover_background": "#425e5eFF",
+        "scrollbar.track.background": "#293e404D",
+        "search.match_background": "#425e5eFF",
+        "status_bar.background": "#0f1c1eFF",
         "success": "#7aa4a1",
         "success.background": "#24383a",
-        "surface.background": "#0f1c1e",
+        "surface.background": "#0f1c1eFF",
         "syntax": {
           "boolean": {
             "color": "#ff9664"
@@ -1161,9 +1167,9 @@
             "color": "#e85c51"
           }
         },
-        "tab.active_background": "#152528",
-        "tab.inactive_background": "#0f1c1e",
-        "tab_bar.background": "#0f1c1e",
+        "tab.active_background": "#293e4080",
+        "tab.inactive_background": "#15252880",
+        "tab_bar.background": "#15252880",
         "terminal.ansi.black": "#2f3239",
         "terminal.ansi.blue": "#5a93aa",
         "terminal.ansi.bright_black": "#4e5157",
@@ -1188,7 +1194,7 @@
         "terminal.ansi.red": "#e85c51",
         "terminal.ansi.white": "#ebebeb",
         "terminal.ansi.yellow": "#fda47f",
-        "terminal.background": "#152528",
+        "terminal.background": "#152528FF",
         "terminal.bright_foreground": "#eaeeee",
         "terminal.dim_foreground": "#cbd9d8",
         "terminal.foreground": "#e6eaea",
@@ -1197,8 +1203,8 @@
         "text.disabled": "#6d7f8b",
         "text.muted": "#e6eaea",
         "text.placeholder": "#587b7b",
-        "title_bar.background": "#0f1c1e",
-        "toolbar.background": "#152528",
+        "title_bar.background": "#0f1c1eFF",
+        "toolbar.background": "#293e4080",
         "version_control.added": "#7aa4a1",
         "version_control.conflict": "#ff8349",
         "version_control.deleted": "#e85c51",
@@ -1211,50 +1217,51 @@
     },
     {
       "appearance": "dark",
-      "name": "Carbonfox",
+      "name": "Carbonfox - opaque",
       "style": {
         "accents": [
-          "#6690d9",
-          "#34bab8",
-          "#a27fd9",
-          "#2b96d9",
-          "#ca4780",
-          "#1fa25a",
-          "#07a19e"
+          "#8cb6ff80",
+          "#5ae0df80",
+          "#c8a5ff80",
+          "#52bdff80",
+          "#f16da680",
+          "#46c88080",
+          "#2dc7c480"
         ],
-        "background": "#2a2a2a",
-        "border": "#252525",
+        "background": "#161616FF",
+        "background.appearance": "opaque",
+        "border": "#252525CC",
         "border.disabled": "#161616",
         "border.focused": "#2a2a2a",
         "border.selected": "#525253",
-        "border.transparent": "#161616",
+        "border.transparent": "#161616FF",
         "border.variant": "#535353",
         "conflict": "#3ddbd9",
         "created": "#25be6a",
         "deleted": "#311d26",
-        "drop_target.background": "#0c0c0c",
-        "editor.active_line.background": "#252525",
+        "drop_target.background": "#0c0c0cFF",
+        "editor.active_line.background": "#2a2a2a4D",
         "editor.active_line_number": "#08bdba",
-        "editor.active_wrap_guide": "#252525",
-        "editor.background": "#161616",
-        "editor.document_highlight.bracket_background": "#2a2a2a",
+        "editor.active_wrap_guide": "#252525FF",
+        "editor.background": "#161616FF",
+        "editor.document_highlight.bracket_background": "#2a2a2aFF",
         "editor.foreground": "#f2f4f8",
-        "editor.gutter.background": "#161616",
-        "editor.indent_guide": "#252525",
-        "editor.indent_guide_active": "#525253",
+        "editor.gutter.background": "#161616FF",
+        "editor.indent_guide": "#252525FF",
+        "editor.indent_guide_active": "#525253FF",
         "editor.line_number": "#7b7c7e",
-        "editor.wrap_guide": "#252525",
+        "editor.wrap_guide": "#25252580",
         "element.active": "#243e3e",
         "element.background": "#1c3736",
         "element.disabled": "#2a2a2a",
         "element.hover": "#1e3d3d",
         "element.selected": "#243e3e",
-        "elevated_surface.background": "#2a2a2a",
+        "elevated_surface.background": "#0c0c0c",
         "error": "#ee5396",
         "error.background": "#361f29",
-        "ghost_element.active": "#525253",
-        "ghost_element.hover": "#5252533F",
-        "ghost_element.selected": "#525253BF",
+        "ghost_element.active": "#525253FF",
+        "ghost_element.hover": "#5252534D",
+        "ghost_element.selected": "#525253CC",
         "hidden": "#7b7c7e",
         "hint": "#6e6f70",
         "hint.background": "#1c3433",
@@ -1263,25 +1270,25 @@
         "info.background": "#252c39",
         "link_text.hover": "#33b1ff",
         "modified": "#08bdba",
-        "panel.background": "#0c0c0c",
-        "panel.focused_border": "#525253",
+        "panel.background": "#0c0c0c4D",
+        "panel.focused_border": "#525253FF",
         "players": [
           {
-            "background": "#353535",
+            "background": "#3535354D",
             "cursor": "#f9fbff",
-            "selection": "#2a2a2a7F"
+            "selection": "#525253CC"
           }
         ],
         "predictive": "#7b7c7e",
         "renamed": "#08bdba",
-        "scrollbar.thumb.background": "#525253BF",
-        "scrollbar.thumb.hover_background": "#525253",
-        "scrollbar.track.background": "#2a2a2a3F",
-        "search.match_background": "#525253",
-        "status_bar.background": "#0c0c0c",
+        "scrollbar.thumb.background": "#525253CC",
+        "scrollbar.thumb.hover_background": "#525253FF",
+        "scrollbar.track.background": "#2a2a2a4D",
+        "search.match_background": "#525253FF",
+        "status_bar.background": "#0c0c0cFF",
         "success": "#25be6a",
         "success.background": "#182f23",
-        "surface.background": "#0c0c0c",
+        "surface.background": "#0c0c0cFF",
         "syntax": {
           "boolean": {
             "color": "#5ae0df"
@@ -1362,9 +1369,9 @@
             "color": "#ee5396"
           }
         },
-        "tab.active_background": "#161616",
-        "tab.inactive_background": "#0c0c0c",
-        "tab_bar.background": "#0c0c0c",
+        "tab.active_background": "#2a2a2a80",
+        "tab.inactive_background": "#16161680",
+        "tab_bar.background": "#16161680",
         "terminal.ansi.black": "#282828",
         "terminal.ansi.blue": "#78a9ff",
         "terminal.ansi.bright_black": "#484848",
@@ -1389,7 +1396,7 @@
         "terminal.ansi.red": "#ee5396",
         "terminal.ansi.white": "#dfdfe0",
         "terminal.ansi.yellow": "#08bdba",
-        "terminal.background": "#161616",
+        "terminal.background": "#161616FF",
         "terminal.bright_foreground": "#f9fbff",
         "terminal.dim_foreground": "#b6b8bb",
         "terminal.foreground": "#f2f4f8",
@@ -1398,8 +1405,1422 @@
         "text.disabled": "#6e6f70",
         "text.muted": "#f2f4f8",
         "text.placeholder": "#7b7c7e",
-        "title_bar.background": "#0c0c0c",
-        "toolbar.background": "#161616",
+        "title_bar.background": "#0c0c0cFF",
+        "toolbar.background": "#2a2a2a80",
+        "version_control.added": "#25be6a",
+        "version_control.conflict": "#3ddbd9",
+        "version_control.deleted": "#ee5396",
+        "version_control.ignored": "#6e6f70",
+        "version_control.modified": "#08bdba",
+        "version_control.renamed": "#08bdba",
+        "warning": "#be95ff",
+        "warning.background": "#2f2939"
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Nightfox - blurred",
+      "style": {
+        "accents": [
+          "#86abdc26",
+          "#f6b07926",
+          "#baa1e226",
+          "#7ad5d626",
+          "#d1698326",
+          "#8ebaa426",
+          "#e0c98926"
+        ],
+        "background": "#192330CC",
+        "background.appearance": "blurred",
+        "border": "#212e3f66",
+        "border.disabled": "#192330",
+        "border.focused": "#2b3b51",
+        "border.selected": "#3c5372",
+        "border.transparent": "#19233000",
+        "border.variant": "#39506d",
+        "conflict": "#f4a261",
+        "created": "#81b29a",
+        "deleted": "#2f2837",
+        "drop_target.background": "#131a24CC",
+        "editor.active_line.background": "#2b3b510D",
+        "editor.active_line_number": "#dbc074",
+        "editor.active_wrap_guide": "#212e3fCC",
+        "editor.background": "#19233000",
+        "editor.document_highlight.bracket_background": "#2b3b51CC",
+        "editor.foreground": "#cdcecf",
+        "editor.gutter.background": "#19233000",
+        "editor.indent_guide": "#212e3fCC",
+        "editor.indent_guide_active": "#3c5372CC",
+        "editor.line_number": "#71839b",
+        "editor.wrap_guide": "#212e3f26",
+        "element.active": "#453f3f",
+        "element.background": "#3d3837",
+        "element.disabled": "#2b3b51",
+        "element.hover": "#453c3a",
+        "element.selected": "#453f3f",
+        "elevated_surface.background": "#131a24",
+        "error": "#c94f6d",
+        "error.background": "#3c2c3c",
+        "ghost_element.active": "#3c5372CC",
+        "ghost_element.hover": "#3c53720D",
+        "ghost_element.selected": "#3c537266",
+        "hidden": "#71839b",
+        "hint": "#738091",
+        "hint.background": "#2e4045",
+        "ignored": "#738091",
+        "info": "#719cd6",
+        "info.background": "#2b3b51",
+        "link_text.hover": "#63cdcf",
+        "modified": "#dbc074",
+        "panel.background": "#131a240D",
+        "panel.focused_border": "#3c5372CC",
+        "players": [
+          {
+            "background": "#29394f0D",
+            "cursor": "#d6d6d7",
+            "selection": "#3c537266"
+          }
+        ],
+        "predictive": "#71839b",
+        "renamed": "#dbc074",
+        "scrollbar.thumb.background": "#3c537266",
+        "scrollbar.thumb.hover_background": "#3c5372CC",
+        "scrollbar.track.background": "#2b3b510D",
+        "search.match_background": "#3c5372CC",
+        "status_bar.background": "#131a24CC",
+        "success": "#81b29a",
+        "success.background": "#2e4045",
+        "surface.background": "#131a24CC",
+        "syntax": {
+          "boolean": {
+            "color": "#f6b079"
+          },
+          "comment": {
+            "color": "#738091"
+          },
+          "comment.doc": {
+            "color": "#738091"
+          },
+          "constant": {
+            "color": "#f6b079"
+          },
+          "constructor": {
+            "color": "#f6b079"
+          },
+          "function": {
+            "color": "#86abdc"
+          },
+          "keyword": {
+            "color": "#9d79d6"
+          },
+          "number": {
+            "color": "#f4a261"
+          },
+          "operator": {
+            "color": "#aeafb0"
+          },
+          "preproc": {
+            "color": "#dc8ed9"
+          },
+          "property": {
+            "color": "#719cd6"
+          },
+          "punctuation": {
+            "color": "#aeafb0"
+          },
+          "punctuation.bracket": {
+            "color": "#aeafb0"
+          },
+          "punctuation.delimiter": {
+            "color": "#aeafb0"
+          },
+          "punctuation.markup": {
+            "color": "#aeafb0"
+          },
+          "punctuation.special": {
+            "color": "#aeafb0"
+          },
+          "string": {
+            "color": "#81b29a"
+          },
+          "string.escape": {
+            "color": "#81b29a"
+          },
+          "string.regex": {
+            "color": "#e0c989"
+          },
+          "string.special": {
+            "color": "#7ad5d6"
+          },
+          "string.special.symbol": {
+            "color": "#c94f6d"
+          },
+          "tag": {
+            "color": "#8567b6"
+          },
+          "text.literal": {
+            "color": "#81b29a"
+          },
+          "type": {
+            "color": "#dbc074"
+          },
+          "variable": {
+            "color": "#63cdcf"
+          },
+          "variable.special": {
+            "color": "#c94f6d"
+          }
+        },
+        "tab.active_background": "#2b3b5126",
+        "tab.inactive_background": "#19233026",
+        "tab_bar.background": "#19233026",
+        "terminal.ansi.black": "#393b44",
+        "terminal.ansi.blue": "#719cd6",
+        "terminal.ansi.bright_black": "#575860",
+        "terminal.ansi.bright_blue": "#86abdc",
+        "terminal.ansi.bright_cyan": "#7ad5d6",
+        "terminal.ansi.bright_green": "#8ebaa4",
+        "terminal.ansi.bright_magenta": "#baa1e2",
+        "terminal.ansi.bright_red": "#d16983",
+        "terminal.ansi.bright_white": "#e4e4e5",
+        "terminal.ansi.bright_yellow": "#e0c989",
+        "terminal.ansi.cyan": "#63cdcf",
+        "terminal.ansi.dim_black": "#30323a",
+        "terminal.ansi.dim_blue": "#6085b6",
+        "terminal.ansi.dim_cyan": "#54aeb0",
+        "terminal.ansi.dim_green": "#6e9783",
+        "terminal.ansi.dim_magenta": "#8567b6",
+        "terminal.ansi.dim_red": "#ab435d",
+        "terminal.ansi.dim_white": "#bebebe",
+        "terminal.ansi.dim_yellow": "#baa363",
+        "terminal.ansi.green": "#81b29a",
+        "terminal.ansi.magenta": "#9d79d6",
+        "terminal.ansi.red": "#c94f6d",
+        "terminal.ansi.white": "#dfdfe0",
+        "terminal.ansi.yellow": "#dbc074",
+        "terminal.background": "#19233000",
+        "terminal.bright_foreground": "#d6d6d7",
+        "terminal.dim_foreground": "#aeafb0",
+        "terminal.foreground": "#cdcecf",
+        "text": "#d6d6d7",
+        "text.accent": "#cf8a52",
+        "text.disabled": "#738091",
+        "text.muted": "#cdcecf",
+        "text.placeholder": "#71839b",
+        "title_bar.background": "#131a24CC",
+        "toolbar.background": "#2b3b5126",
+        "version_control.added": "#81b29a",
+        "version_control.conflict": "#f4a261",
+        "version_control.deleted": "#c94f6d",
+        "version_control.ignored": "#738091",
+        "version_control.modified": "#dbc074",
+        "version_control.renamed": "#dbc074",
+        "warning": "#dbc074",
+        "warning.background": "#40423e"
+      }
+    },
+    {
+      "appearance": "light",
+      "name": "Dayfox - blurred",
+      "style": {
+        "accents": [
+          "#4863b626",
+          "#a5777926",
+          "#8452d526",
+          "#488d9326",
+          "#b3434e26",
+          "#577f6326",
+          "#b86e2826"
+        ],
+        "background": "#f6f2eeCC",
+        "background.appearance": "blurred",
+        "border": "#dbd1dd66",
+        "border.disabled": "#f6f2ee",
+        "border.focused": "#e7d2be",
+        "border.selected": "#a4c1c2",
+        "border.transparent": "#f6f2ee00",
+        "border.variant": "#aab0ad",
+        "conflict": "#955f61",
+        "created": "#396847",
+        "deleted": "#e6c8c8",
+        "drop_target.background": "#e4dcd4CC",
+        "editor.active_line.background": "#e7d2be0D",
+        "editor.active_line_number": "#ac5402",
+        "editor.active_wrap_guide": "#dbd1ddCC",
+        "editor.background": "#f6f2ee00",
+        "editor.document_highlight.bracket_background": "#e7d2beCC",
+        "editor.foreground": "#3d2b5a",
+        "editor.gutter.background": "#f6f2ee00",
+        "editor.indent_guide": "#dbd1ddCC",
+        "editor.indent_guide_active": "#a4c1c2CC",
+        "editor.line_number": "#824d5b",
+        "editor.wrap_guide": "#dbd1dd26",
+        "element.active": "#e6d9d7",
+        "element.background": "#ded2cf",
+        "element.disabled": "#e7d2be",
+        "element.hover": "#e3d5d2",
+        "element.selected": "#e6d9d7",
+        "elevated_surface.background": "#e4dcd4",
+        "error": "#a5222f",
+        "error.background": "#deb4b5",
+        "ghost_element.active": "#a4c1c2CC",
+        "ghost_element.hover": "#a4c1c20D",
+        "ghost_element.selected": "#a4c1c266",
+        "hidden": "#824d5b",
+        "hint": "#837a72",
+        "hint.background": "#bdc9bc",
+        "ignored": "#837a72",
+        "info": "#2848a9",
+        "info.background": "#b8bfd9",
+        "link_text.hover": "#287980",
+        "modified": "#ac5402",
+        "panel.background": "#e4dcd40D",
+        "panel.focused_border": "#a4c1c2CC",
+        "players": [
+          {
+            "background": "#d3c7bb0D",
+            "cursor": "#302b5d",
+            "selection": "#a4c1c266"
+          }
+        ],
+        "predictive": "#824d5b",
+        "renamed": "#ac5402",
+        "scrollbar.thumb.background": "#a4c1c266",
+        "scrollbar.thumb.hover_background": "#a4c1c2CC",
+        "scrollbar.track.background": "#e7d2be0D",
+        "search.match_background": "#a4c1c2CC",
+        "status_bar.background": "#e4dcd4CC",
+        "success": "#396847",
+        "success.background": "#bdc9bc",
+        "surface.background": "#e4dcd4CC",
+        "syntax": {
+          "boolean": {
+            "color": "#7f5152"
+          },
+          "comment": {
+            "color": "#837a72"
+          },
+          "comment.doc": {
+            "color": "#837a72"
+          },
+          "constant": {
+            "color": "#7f5152"
+          },
+          "constructor": {
+            "color": "#7f5152"
+          },
+          "function": {
+            "color": "#223d90"
+          },
+          "keyword": {
+            "color": "#6e33ce"
+          },
+          "number": {
+            "color": "#955f61"
+          },
+          "operator": {
+            "color": "#643f61"
+          },
+          "preproc": {
+            "color": "#8b369a"
+          },
+          "property": {
+            "color": "#2848a9"
+          },
+          "punctuation": {
+            "color": "#643f61"
+          },
+          "punctuation.bracket": {
+            "color": "#643f61"
+          },
+          "punctuation.delimiter": {
+            "color": "#643f61"
+          },
+          "punctuation.markup": {
+            "color": "#643f61"
+          },
+          "punctuation.special": {
+            "color": "#643f61"
+          },
+          "string": {
+            "color": "#396847"
+          },
+          "string.escape": {
+            "color": "#396847"
+          },
+          "string.regex": {
+            "color": "#924702"
+          },
+          "string.special": {
+            "color": "#22676d"
+          },
+          "string.special.symbol": {
+            "color": "#a5222f"
+          },
+          "tag": {
+            "color": "#5e2baf"
+          },
+          "text.literal": {
+            "color": "#396847"
+          },
+          "type": {
+            "color": "#ac5402"
+          },
+          "variable": {
+            "color": "#287980"
+          },
+          "variable.special": {
+            "color": "#a5222f"
+          }
+        },
+        "tab.active_background": "#e7d2be26",
+        "tab.inactive_background": "#f6f2ee26",
+        "tab_bar.background": "#f6f2ee26",
+        "terminal.ansi.black": "#352c24",
+        "terminal.ansi.blue": "#2848a9",
+        "terminal.ansi.bright_black": "#534c45",
+        "terminal.ansi.bright_blue": "#4863b6",
+        "terminal.ansi.bright_cyan": "#488d93",
+        "terminal.ansi.bright_green": "#577f63",
+        "terminal.ansi.bright_magenta": "#8452d5",
+        "terminal.ansi.bright_red": "#b3434e",
+        "terminal.ansi.bright_white": "#f4ece6",
+        "terminal.ansi.bright_yellow": "#b86e28",
+        "terminal.ansi.cyan": "#287980",
+        "terminal.ansi.dim_black": "#2d251f",
+        "terminal.ansi.dim_blue": "#223d90",
+        "terminal.ansi.dim_cyan": "#22676d",
+        "terminal.ansi.dim_green": "#30583c",
+        "terminal.ansi.dim_magenta": "#5e2baf",
+        "terminal.ansi.dim_red": "#8c1d28",
+        "terminal.ansi.dim_white": "#cec6bf",
+        "terminal.ansi.dim_yellow": "#924702",
+        "terminal.ansi.green": "#396847",
+        "terminal.ansi.magenta": "#6e33ce",
+        "terminal.ansi.red": "#a5222f",
+        "terminal.ansi.white": "#f2e9e1",
+        "terminal.ansi.yellow": "#ac5402",
+        "terminal.background": "#f6f2ee00",
+        "terminal.bright_foreground": "#302b5d",
+        "terminal.dim_foreground": "#643f61",
+        "terminal.foreground": "#3d2b5a",
+        "text": "#302b5d",
+        "text.accent": "#7f5152",
+        "text.disabled": "#837a72",
+        "text.muted": "#3d2b5a",
+        "text.placeholder": "#824d5b",
+        "title_bar.background": "#e4dcd4CC",
+        "toolbar.background": "#e7d2be26",
+        "version_control.added": "#396847",
+        "version_control.conflict": "#955f61",
+        "version_control.deleted": "#a5222f",
+        "version_control.ignored": "#837a72",
+        "version_control.modified": "#ac5402",
+        "version_control.renamed": "#ac5402",
+        "warning": "#ac5402",
+        "warning.background": "#e0c3a7"
+      }
+    },
+    {
+      "appearance": "light",
+      "name": "Dawnfox - blurred",
+      "style": {
+        "accents": [
+          "#2d81a326",
+          "#de8c8826",
+          "#9a80b926",
+          "#5ca7b426",
+          "#c26d8526",
+          "#629f8126",
+          "#eea84626"
+        ],
+        "background": "#faf4edCC",
+        "background.appearance": "blurred",
+        "border": "#ebe0df66",
+        "border.disabled": "#faf4ed",
+        "border.focused": "#d0d8d8",
+        "border.selected": "#b8cece",
+        "border.transparent": "#faf4ed00",
+        "border.variant": "#bdbfc9",
+        "conflict": "#d7827e",
+        "created": "#618774",
+        "deleted": "#ecd7d6",
+        "drop_target.background": "#ebe5dfCC",
+        "editor.active_line.background": "#d0d8d80D",
+        "editor.active_line_number": "#ea9d34",
+        "editor.active_wrap_guide": "#ebe0dfCC",
+        "editor.background": "#faf4ed00",
+        "editor.document_highlight.bracket_background": "#d0d8d8CC",
+        "editor.foreground": "#575279",
+        "editor.gutter.background": "#faf4ed00",
+        "editor.indent_guide": "#ebe0dfCC",
+        "editor.indent_guide_active": "#b8ceceCC",
+        "editor.line_number": "#a8a3b3",
+        "editor.wrap_guide": "#ebe0df26",
+        "element.active": "#f4dfd9",
+        "element.background": "#f0d9d3",
+        "element.disabled": "#d0d8d8",
+        "element.hover": "#f3ddd7",
+        "element.selected": "#f4dfd9",
+        "elevated_surface.background": "#ebe5df",
+        "error": "#b4637a",
+        "error.background": "#e5c9cb",
+        "ghost_element.active": "#b8ceceCC",
+        "ghost_element.hover": "#b8cece0D",
+        "ghost_element.selected": "#b8cece66",
+        "hidden": "#a8a3b3",
+        "hint": "#9893a5",
+        "hint.background": "#ccd3c9",
+        "ignored": "#9893a5",
+        "info": "#286983",
+        "info.background": "#bbcacd",
+        "link_text.hover": "#56949f",
+        "modified": "#ea9d34",
+        "panel.background": "#ebe5df0D",
+        "panel.focused_border": "#b8ceceCC",
+        "players": [
+          {
+            "background": "#ebdfe40D",
+            "cursor": "#4c4769",
+            "selection": "#b8cece66"
+          }
+        ],
+        "predictive": "#a8a3b3",
+        "renamed": "#ea9d34",
+        "scrollbar.thumb.background": "#b8cece66",
+        "scrollbar.thumb.hover_background": "#b8ceceCC",
+        "scrollbar.track.background": "#d0d8d80D",
+        "search.match_background": "#b8ceceCC",
+        "status_bar.background": "#ebe5dfCC",
+        "success": "#618774",
+        "success.background": "#ccd3c9",
+        "surface.background": "#ebe5dfCC",
+        "syntax": {
+          "boolean": {
+            "color": "#ca6e69"
+          },
+          "comment": {
+            "color": "#9893a5"
+          },
+          "comment.doc": {
+            "color": "#9893a5"
+          },
+          "constant": {
+            "color": "#ca6e69"
+          },
+          "constructor": {
+            "color": "#ca6e69"
+          },
+          "function": {
+            "color": "#295e73"
+          },
+          "keyword": {
+            "color": "#907aa9"
+          },
+          "number": {
+            "color": "#d7827e"
+          },
+          "operator": {
+            "color": "#625c87"
+          },
+          "preproc": {
+            "color": "#c9709e"
+          },
+          "property": {
+            "color": "#286983"
+          },
+          "punctuation": {
+            "color": "#625c87"
+          },
+          "punctuation.bracket": {
+            "color": "#625c87"
+          },
+          "punctuation.delimiter": {
+            "color": "#625c87"
+          },
+          "punctuation.markup": {
+            "color": "#625c87"
+          },
+          "punctuation.special": {
+            "color": "#625c87"
+          },
+          "string": {
+            "color": "#618774"
+          },
+          "string.escape": {
+            "color": "#618774"
+          },
+          "string.regex": {
+            "color": "#dd9024"
+          },
+          "string.special": {
+            "color": "#50848c"
+          },
+          "string.special.symbol": {
+            "color": "#b4637a"
+          },
+          "tag": {
+            "color": "#816b9a"
+          },
+          "text.literal": {
+            "color": "#618774"
+          },
+          "type": {
+            "color": "#ea9d34"
+          },
+          "variable": {
+            "color": "#56949f"
+          },
+          "variable.special": {
+            "color": "#b4637a"
+          }
+        },
+        "tab.active_background": "#d0d8d826",
+        "tab.inactive_background": "#faf4ed26",
+        "tab_bar.background": "#faf4ed26",
+        "terminal.ansi.black": "#575279",
+        "terminal.ansi.blue": "#286983",
+        "terminal.ansi.bright_black": "#5f5695",
+        "terminal.ansi.bright_blue": "#2d81a3",
+        "terminal.ansi.bright_cyan": "#5ca7b4",
+        "terminal.ansi.bright_green": "#629f81",
+        "terminal.ansi.bright_magenta": "#9a80b9",
+        "terminal.ansi.bright_red": "#c26d85",
+        "terminal.ansi.bright_white": "#e6ebf3",
+        "terminal.ansi.bright_yellow": "#eea846",
+        "terminal.ansi.cyan": "#56949f",
+        "terminal.ansi.dim_black": "#504c6b",
+        "terminal.ansi.dim_blue": "#295e73",
+        "terminal.ansi.dim_cyan": "#50848c",
+        "terminal.ansi.dim_green": "#597668",
+        "terminal.ansi.dim_magenta": "#816b9a",
+        "terminal.ansi.dim_red": "#a5576d",
+        "terminal.ansi.dim_white": "#c8cfde",
+        "terminal.ansi.dim_yellow": "#dd9024",
+        "terminal.ansi.green": "#618774",
+        "terminal.ansi.magenta": "#907aa9",
+        "terminal.ansi.red": "#b4637a",
+        "terminal.ansi.white": "#e5e9f0",
+        "terminal.ansi.yellow": "#ea9d34",
+        "terminal.background": "#faf4ed00",
+        "terminal.bright_foreground": "#4c4769",
+        "terminal.dim_foreground": "#625c87",
+        "terminal.foreground": "#575279",
+        "text": "#4c4769",
+        "text.accent": "#ca6e69",
+        "text.disabled": "#9893a5",
+        "text.muted": "#575279",
+        "text.placeholder": "#a8a3b3",
+        "title_bar.background": "#ebe5dfCC",
+        "toolbar.background": "#d0d8d826",
+        "version_control.added": "#618774",
+        "version_control.conflict": "#d7827e",
+        "version_control.deleted": "#b4637a",
+        "version_control.ignored": "#9893a5",
+        "version_control.modified": "#ea9d34",
+        "version_control.renamed": "#ea9d34",
+        "warning": "#ea9d34",
+        "warning.background": "#f5dab6"
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Duskfox - blurred",
+      "style": {
+        "accents": [
+          "#65b1cd26",
+          "#f0a4a226",
+          "#ccb1ed26",
+          "#a6dae326",
+          "#f083a226",
+          "#b1d19626",
+          "#f9cb8c26"
+        ],
+        "background": "#232136CC",
+        "background.appearance": "blurred",
+        "border": "#2d2a4566",
+        "border.disabled": "#232136",
+        "border.focused": "#433c59",
+        "border.selected": "#63577d",
+        "border.transparent": "#23213600",
+        "border.variant": "#4b4673",
+        "conflict": "#ea9a97",
+        "created": "#a3be8c",
+        "deleted": "#4b3148",
+        "drop_target.background": "#191726CC",
+        "editor.active_line.background": "#433c590D",
+        "editor.active_line_number": "#f6c177",
+        "editor.active_wrap_guide": "#2d2a45CC",
+        "editor.background": "#23213600",
+        "editor.document_highlight.bracket_background": "#433c59CC",
+        "editor.foreground": "#e0def4",
+        "editor.gutter.background": "#23213600",
+        "editor.indent_guide": "#2d2a45CC",
+        "editor.indent_guide_active": "#63577dCC",
+        "editor.line_number": "#6e6a86",
+        "editor.wrap_guide": "#2d2a4526",
+        "element.active": "#4c3b4c",
+        "element.background": "#473241",
+        "element.disabled": "#433c59",
+        "element.hover": "#4b3949",
+        "element.selected": "#4c3b4c",
+        "elevated_surface.background": "#191726",
+        "error": "#eb6f92",
+        "error.background": "#412d44",
+        "ghost_element.active": "#63577dCC",
+        "ghost_element.hover": "#63577d0D",
+        "ghost_element.selected": "#63577d66",
+        "hidden": "#6e6a86",
+        "hint": "#817c9c",
+        "hint.background": "#363943",
+        "ignored": "#817c9c",
+        "info": "#569fba",
+        "info.background": "#2b344a",
+        "link_text.hover": "#9ccfd8",
+        "modified": "#f6c177",
+        "panel.background": "#1917260D",
+        "panel.focused_border": "#63577dCC",
+        "players": [
+          {
+            "background": "#3733540D",
+            "cursor": "#eae8ff",
+            "selection": "#63577d66"
+          }
+        ],
+        "predictive": "#6e6a86",
+        "renamed": "#f6c177",
+        "scrollbar.thumb.background": "#63577d66",
+        "scrollbar.thumb.hover_background": "#63577dCC",
+        "scrollbar.track.background": "#433c590D",
+        "search.match_background": "#63577dCC",
+        "status_bar.background": "#191726CC",
+        "success": "#a3be8c",
+        "success.background": "#363943",
+        "surface.background": "#191726CC",
+        "syntax": {
+          "boolean": {
+            "color": "#f0a4a2"
+          },
+          "comment": {
+            "color": "#817c9c"
+          },
+          "comment.doc": {
+            "color": "#817c9c"
+          },
+          "constant": {
+            "color": "#f0a4a2"
+          },
+          "constructor": {
+            "color": "#f0a4a2"
+          },
+          "function": {
+            "color": "#65b1cd"
+          },
+          "keyword": {
+            "color": "#c4a7e7"
+          },
+          "number": {
+            "color": "#ea9a97"
+          },
+          "operator": {
+            "color": "#cdcbe0"
+          },
+          "preproc": {
+            "color": "#f0a6cc"
+          },
+          "property": {
+            "color": "#569fba"
+          },
+          "punctuation": {
+            "color": "#cdcbe0"
+          },
+          "punctuation.bracket": {
+            "color": "#cdcbe0"
+          },
+          "punctuation.delimiter": {
+            "color": "#cdcbe0"
+          },
+          "punctuation.markup": {
+            "color": "#cdcbe0"
+          },
+          "punctuation.special": {
+            "color": "#cdcbe0"
+          },
+          "string": {
+            "color": "#a3be8c"
+          },
+          "string.escape": {
+            "color": "#a3be8c"
+          },
+          "string.regex": {
+            "color": "#f9cb8c"
+          },
+          "string.special": {
+            "color": "#a6dae3"
+          },
+          "string.special.symbol": {
+            "color": "#eb6f92"
+          },
+          "tag": {
+            "color": "#a580d2"
+          },
+          "text.literal": {
+            "color": "#a3be8c"
+          },
+          "type": {
+            "color": "#f6c177"
+          },
+          "variable": {
+            "color": "#9ccfd8"
+          },
+          "variable.special": {
+            "color": "#eb6f92"
+          }
+        },
+        "tab.active_background": "#433c5926",
+        "tab.inactive_background": "#23213626",
+        "tab_bar.background": "#23213626",
+        "terminal.ansi.black": "#393552",
+        "terminal.ansi.blue": "#569fba",
+        "terminal.ansi.bright_black": "#47407d",
+        "terminal.ansi.bright_blue": "#65b1cd",
+        "terminal.ansi.bright_cyan": "#a6dae3",
+        "terminal.ansi.bright_green": "#b1d196",
+        "terminal.ansi.bright_magenta": "#ccb1ed",
+        "terminal.ansi.bright_red": "#f083a2",
+        "terminal.ansi.bright_white": "#e2e0f7",
+        "terminal.ansi.bright_yellow": "#f9cb8c",
+        "terminal.ansi.cyan": "#9ccfd8",
+        "terminal.ansi.dim_black": "#322e42",
+        "terminal.ansi.dim_blue": "#4a869c",
+        "terminal.ansi.dim_cyan": "#7bb8c1",
+        "terminal.ansi.dim_green": "#8aa872",
+        "terminal.ansi.dim_magenta": "#a580d2",
+        "terminal.ansi.dim_red": "#d84f76",
+        "terminal.ansi.dim_white": "#b1acde",
+        "terminal.ansi.dim_yellow": "#e6a852",
+        "terminal.ansi.green": "#a3be8c",
+        "terminal.ansi.magenta": "#c4a7e7",
+        "terminal.ansi.red": "#eb6f92",
+        "terminal.ansi.white": "#e0def4",
+        "terminal.ansi.yellow": "#f6c177",
+        "terminal.background": "#23213600",
+        "terminal.bright_foreground": "#eae8ff",
+        "terminal.dim_foreground": "#cdcbe0",
+        "terminal.foreground": "#e0def4",
+        "text": "#eae8ff",
+        "text.accent": "#d6746f",
+        "text.disabled": "#817c9c",
+        "text.muted": "#e0def4",
+        "text.placeholder": "#6e6a86",
+        "title_bar.background": "#191726CC",
+        "toolbar.background": "#433c5926",
+        "version_control.added": "#a3be8c",
+        "version_control.conflict": "#ea9a97",
+        "version_control.deleted": "#eb6f92",
+        "version_control.ignored": "#817c9c",
+        "version_control.modified": "#f6c177",
+        "version_control.renamed": "#f6c177",
+        "warning": "#f6c177",
+        "warning.background": "#433940"
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Nordfox - blurred",
+      "style": {
+        "accents": [
+          "#8cafd226",
+          "#d8907926",
+          "#c895bf26",
+          "#93ccdc26",
+          "#d06f7926",
+          "#b1d19626",
+          "#f0d39926"
+        ],
+        "background": "#2e3440CC",
+        "background.appearance": "blurred",
+        "border": "#39404f66",
+        "border.disabled": "#2e3440",
+        "border.focused": "#3e4a5b",
+        "border.selected": "#4f6074",
+        "border.transparent": "#2e344000",
+        "border.variant": "#5a657d",
+        "conflict": "#c9826b",
+        "created": "#a3be8c",
+        "deleted": "#403843",
+        "drop_target.background": "#232831CC",
+        "editor.active_line.background": "#3e4a5b0D",
+        "editor.active_line_number": "#ebcb8b",
+        "editor.active_wrap_guide": "#39404fCC",
+        "editor.background": "#2e344000",
+        "editor.document_highlight.bracket_background": "#3e4a5bCC",
+        "editor.foreground": "#cdcecf",
+        "editor.gutter.background": "#2e344000",
+        "editor.indent_guide": "#39404fCC",
+        "editor.indent_guide_active": "#4f6074CC",
+        "editor.line_number": "#7e8188",
+        "editor.wrap_guide": "#39404f26",
+        "element.active": "#50464b",
+        "element.background": "#493f43",
+        "element.disabled": "#3e4a5b",
+        "element.hover": "#4d4449",
+        "element.selected": "#50464b",
+        "elevated_surface.background": "#232831",
+        "error": "#bf616a",
+        "error.background": "#4b3d48",
+        "ghost_element.active": "#4f6074CC",
+        "ghost_element.hover": "#4f60740D",
+        "ghost_element.selected": "#4f607466",
+        "hidden": "#7e8188",
+        "hint": "#60728a",
+        "hint.background": "#45504f",
+        "ignored": "#60728a",
+        "info": "#81a1c1",
+        "info.background": "#3f4a5a",
+        "link_text.hover": "#88c0d0",
+        "modified": "#ebcb8b",
+        "panel.background": "#2328310D",
+        "panel.focused_border": "#4f6074CC",
+        "players": [
+          {
+            "background": "#444c5e0D",
+            "cursor": "#c7cdd9",
+            "selection": "#4f607466"
+          }
+        ],
+        "predictive": "#7e8188",
+        "renamed": "#ebcb8b",
+        "scrollbar.thumb.background": "#4f607466",
+        "scrollbar.thumb.hover_background": "#4f6074CC",
+        "scrollbar.track.background": "#3e4a5b0D",
+        "search.match_background": "#4f6074CC",
+        "status_bar.background": "#232831CC",
+        "success": "#a3be8c",
+        "success.background": "#45504f",
+        "surface.background": "#232831CC",
+        "syntax": {
+          "boolean": {
+            "color": "#d89079"
+          },
+          "comment": {
+            "color": "#60728a"
+          },
+          "comment.doc": {
+            "color": "#60728a"
+          },
+          "constant": {
+            "color": "#d89079"
+          },
+          "constructor": {
+            "color": "#d89079"
+          },
+          "function": {
+            "color": "#8cafd2"
+          },
+          "keyword": {
+            "color": "#b48ead"
+          },
+          "number": {
+            "color": "#c9826b"
+          },
+          "operator": {
+            "color": "#abb1bb"
+          },
+          "preproc": {
+            "color": "#d092ce"
+          },
+          "property": {
+            "color": "#81a1c1"
+          },
+          "punctuation": {
+            "color": "#abb1bb"
+          },
+          "punctuation.bracket": {
+            "color": "#abb1bb"
+          },
+          "punctuation.delimiter": {
+            "color": "#abb1bb"
+          },
+          "punctuation.markup": {
+            "color": "#abb1bb"
+          },
+          "punctuation.special": {
+            "color": "#abb1bb"
+          },
+          "string": {
+            "color": "#a3be8c"
+          },
+          "string.escape": {
+            "color": "#a3be8c"
+          },
+          "string.regex": {
+            "color": "#f0d399"
+          },
+          "string.special": {
+            "color": "#93ccdc"
+          },
+          "string.special.symbol": {
+            "color": "#bf616a"
+          },
+          "tag": {
+            "color": "#9d7495"
+          },
+          "text.literal": {
+            "color": "#a3be8c"
+          },
+          "type": {
+            "color": "#ebcb8b"
+          },
+          "variable": {
+            "color": "#88c0d0"
+          },
+          "variable.special": {
+            "color": "#bf616a"
+          }
+        },
+        "tab.active_background": "#3e4a5b26",
+        "tab.inactive_background": "#2e344026",
+        "tab_bar.background": "#2e344026",
+        "terminal.ansi.black": "#3b4252",
+        "terminal.ansi.blue": "#81a1c1",
+        "terminal.ansi.bright_black": "#465780",
+        "terminal.ansi.bright_blue": "#8cafd2",
+        "terminal.ansi.bright_cyan": "#93ccdc",
+        "terminal.ansi.bright_green": "#b1d196",
+        "terminal.ansi.bright_magenta": "#c895bf",
+        "terminal.ansi.bright_red": "#d06f79",
+        "terminal.ansi.bright_white": "#e7ecf4",
+        "terminal.ansi.bright_yellow": "#f0d399",
+        "terminal.ansi.cyan": "#88c0d0",
+        "terminal.ansi.dim_black": "#353a45",
+        "terminal.ansi.dim_blue": "#668aab",
+        "terminal.ansi.dim_cyan": "#69a7ba",
+        "terminal.ansi.dim_green": "#8aa872",
+        "terminal.ansi.dim_magenta": "#9d7495",
+        "terminal.ansi.dim_red": "#a54e56",
+        "terminal.ansi.dim_white": "#bbc3d4",
+        "terminal.ansi.dim_yellow": "#d9b263",
+        "terminal.ansi.green": "#a3be8c",
+        "terminal.ansi.magenta": "#b48ead",
+        "terminal.ansi.red": "#bf616a",
+        "terminal.ansi.white": "#e5e9f0",
+        "terminal.ansi.yellow": "#ebcb8b",
+        "terminal.background": "#2e344000",
+        "terminal.bright_foreground": "#c7cdd9",
+        "terminal.dim_foreground": "#abb1bb",
+        "terminal.foreground": "#cdcecf",
+        "text": "#c7cdd9",
+        "text.accent": "#b46950",
+        "text.disabled": "#60728a",
+        "text.muted": "#cdcecf",
+        "text.placeholder": "#7e8188",
+        "title_bar.background": "#232831CC",
+        "toolbar.background": "#3e4a5b26",
+        "version_control.added": "#a3be8c",
+        "version_control.conflict": "#c9826b",
+        "version_control.deleted": "#bf616a",
+        "version_control.ignored": "#60728a",
+        "version_control.modified": "#ebcb8b",
+        "version_control.renamed": "#ebcb8b",
+        "warning": "#ebcb8b",
+        "warning.background": "#54524f"
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Terafox - blurred",
+      "style": {
+        "accents": [
+          "#73a3b726",
+          "#ff966426",
+          "#b9749026",
+          "#afd4de26",
+          "#eb746b26",
+          "#8eb2af26",
+          "#fdb29226"
+        ],
+        "background": "#152528CC",
+        "background.appearance": "blurred",
+        "border": "#1d333766",
+        "border.disabled": "#152528",
+        "border.focused": "#293e40",
+        "border.selected": "#425e5e",
+        "border.transparent": "#15252800",
+        "border.variant": "#2d4f56",
+        "conflict": "#ff8349",
+        "created": "#7aa4a1",
+        "deleted": "#4a3332",
+        "drop_target.background": "#0f1c1eCC",
+        "editor.active_line.background": "#293e400D",
+        "editor.active_line_number": "#fda47f",
+        "editor.active_wrap_guide": "#1d3337CC",
+        "editor.background": "#15252800",
+        "editor.document_highlight.bracket_background": "#293e40CC",
+        "editor.foreground": "#e6eaea",
+        "editor.gutter.background": "#15252800",
+        "editor.indent_guide": "#1d3337CC",
+        "editor.indent_guide_active": "#425e5eCC",
+        "editor.line_number": "#587b7b",
+        "editor.wrap_guide": "#1d333726",
+        "element.active": "#443c34",
+        "element.background": "#3c342c",
+        "element.disabled": "#293e40",
+        "element.hover": "#44382f",
+        "element.selected": "#443c34",
+        "elevated_surface.background": "#0f1c1e",
+        "error": "#e85c51",
+        "error.background": "#352d2e",
+        "ghost_element.active": "#425e5eCC",
+        "ghost_element.hover": "#425e5e0D",
+        "ghost_element.selected": "#425e5e66",
+        "hidden": "#587b7b",
+        "hint": "#6d7f8b",
+        "hint.background": "#24383a",
+        "ignored": "#6d7f8b",
+        "info": "#5a93aa",
+        "info.background": "#1f353c",
+        "link_text.hover": "#a1cdd8",
+        "modified": "#fda47f",
+        "panel.background": "#0f1c1e0D",
+        "panel.focused_border": "#425e5eCC",
+        "players": [
+          {
+            "background": "#2541470D",
+            "cursor": "#eaeeee",
+            "selection": "#425e5e66"
+          }
+        ],
+        "predictive": "#587b7b",
+        "renamed": "#fda47f",
+        "scrollbar.thumb.background": "#425e5e66",
+        "scrollbar.thumb.hover_background": "#425e5eCC",
+        "scrollbar.track.background": "#293e400D",
+        "search.match_background": "#425e5eCC",
+        "status_bar.background": "#0f1c1eCC",
+        "success": "#7aa4a1",
+        "success.background": "#24383a",
+        "surface.background": "#0f1c1eCC",
+        "syntax": {
+          "boolean": {
+            "color": "#ff9664"
+          },
+          "comment": {
+            "color": "#6d7f8b"
+          },
+          "comment.doc": {
+            "color": "#6d7f8b"
+          },
+          "constant": {
+            "color": "#ff9664"
+          },
+          "constructor": {
+            "color": "#ff9664"
+          },
+          "function": {
+            "color": "#73a3b7"
+          },
+          "keyword": {
+            "color": "#ad5c7c"
+          },
+          "number": {
+            "color": "#ff8349"
+          },
+          "operator": {
+            "color": "#cbd9d8"
+          },
+          "preproc": {
+            "color": "#d38d97"
+          },
+          "property": {
+            "color": "#5a93aa"
+          },
+          "punctuation": {
+            "color": "#cbd9d8"
+          },
+          "punctuation.bracket": {
+            "color": "#cbd9d8"
+          },
+          "punctuation.delimiter": {
+            "color": "#cbd9d8"
+          },
+          "punctuation.markup": {
+            "color": "#cbd9d8"
+          },
+          "punctuation.special": {
+            "color": "#cbd9d8"
+          },
+          "string": {
+            "color": "#7aa4a1"
+          },
+          "string.escape": {
+            "color": "#7aa4a1"
+          },
+          "string.regex": {
+            "color": "#fdb292"
+          },
+          "string.special": {
+            "color": "#afd4de"
+          },
+          "string.special.symbol": {
+            "color": "#e85c51"
+          },
+          "tag": {
+            "color": "#934e69"
+          },
+          "text.literal": {
+            "color": "#7aa4a1"
+          },
+          "type": {
+            "color": "#fda47f"
+          },
+          "variable": {
+            "color": "#a1cdd8"
+          },
+          "variable.special": {
+            "color": "#e85c51"
+          }
+        },
+        "tab.active_background": "#293e4026",
+        "tab.inactive_background": "#15252826",
+        "tab_bar.background": "#15252826",
+        "terminal.ansi.black": "#2f3239",
+        "terminal.ansi.blue": "#5a93aa",
+        "terminal.ansi.bright_black": "#4e5157",
+        "terminal.ansi.bright_blue": "#73a3b7",
+        "terminal.ansi.bright_cyan": "#afd4de",
+        "terminal.ansi.bright_green": "#8eb2af",
+        "terminal.ansi.bright_magenta": "#b97490",
+        "terminal.ansi.bright_red": "#eb746b",
+        "terminal.ansi.bright_white": "#eeeeee",
+        "terminal.ansi.bright_yellow": "#fdb292",
+        "terminal.ansi.cyan": "#a1cdd8",
+        "terminal.ansi.dim_black": "#282a30",
+        "terminal.ansi.dim_blue": "#4d7d90",
+        "terminal.ansi.dim_cyan": "#89aeb8",
+        "terminal.ansi.dim_green": "#688b89",
+        "terminal.ansi.dim_magenta": "#934e69",
+        "terminal.ansi.dim_red": "#c54e45",
+        "terminal.ansi.dim_white": "#c8c8c8",
+        "terminal.ansi.dim_yellow": "#d78b6c",
+        "terminal.ansi.green": "#7aa4a1",
+        "terminal.ansi.magenta": "#ad5c7c",
+        "terminal.ansi.red": "#e85c51",
+        "terminal.ansi.white": "#ebebeb",
+        "terminal.ansi.yellow": "#fda47f",
+        "terminal.background": "#15252800",
+        "terminal.bright_foreground": "#eaeeee",
+        "terminal.dim_foreground": "#cbd9d8",
+        "terminal.foreground": "#e6eaea",
+        "text": "#eaeeee",
+        "text.accent": "#d96f3e",
+        "text.disabled": "#6d7f8b",
+        "text.muted": "#e6eaea",
+        "text.placeholder": "#587b7b",
+        "title_bar.background": "#0f1c1eCC",
+        "toolbar.background": "#293e4026",
+        "version_control.added": "#7aa4a1",
+        "version_control.conflict": "#ff8349",
+        "version_control.deleted": "#e85c51",
+        "version_control.ignored": "#6d7f8b",
+        "version_control.modified": "#fda47f",
+        "version_control.renamed": "#fda47f",
+        "warning": "#fda47f",
+        "warning.background": "#383835"
+      }
+    },
+    {
+      "appearance": "dark",
+      "name": "Carbonfox - blurred",
+      "style": {
+        "accents": [
+          "#8cb6ff26",
+          "#5ae0df26",
+          "#c8a5ff26",
+          "#52bdff26",
+          "#f16da626",
+          "#46c88026",
+          "#2dc7c426"
+        ],
+        "background": "#161616CC",
+        "background.appearance": "blurred",
+        "border": "#25252566",
+        "border.disabled": "#161616",
+        "border.focused": "#2a2a2a",
+        "border.selected": "#525253",
+        "border.transparent": "#16161600",
+        "border.variant": "#535353",
+        "conflict": "#3ddbd9",
+        "created": "#25be6a",
+        "deleted": "#311d26",
+        "drop_target.background": "#0c0c0cCC",
+        "editor.active_line.background": "#2a2a2a0D",
+        "editor.active_line_number": "#08bdba",
+        "editor.active_wrap_guide": "#252525CC",
+        "editor.background": "#16161600",
+        "editor.document_highlight.bracket_background": "#2a2a2aCC",
+        "editor.foreground": "#f2f4f8",
+        "editor.gutter.background": "#16161600",
+        "editor.indent_guide": "#252525CC",
+        "editor.indent_guide_active": "#525253CC",
+        "editor.line_number": "#7b7c7e",
+        "editor.wrap_guide": "#25252526",
+        "element.active": "#243e3e",
+        "element.background": "#1c3736",
+        "element.disabled": "#2a2a2a",
+        "element.hover": "#1e3d3d",
+        "element.selected": "#243e3e",
+        "elevated_surface.background": "#0c0c0c",
+        "error": "#ee5396",
+        "error.background": "#361f29",
+        "ghost_element.active": "#525253CC",
+        "ghost_element.hover": "#5252530D",
+        "ghost_element.selected": "#52525366",
+        "hidden": "#7b7c7e",
+        "hint": "#6e6f70",
+        "hint.background": "#1c3433",
+        "ignored": "#6e6f70",
+        "info": "#78a9ff",
+        "info.background": "#252c39",
+        "link_text.hover": "#33b1ff",
+        "modified": "#08bdba",
+        "panel.background": "#0c0c0c0D",
+        "panel.focused_border": "#525253CC",
+        "players": [
+          {
+            "background": "#3535350D",
+            "cursor": "#f9fbff",
+            "selection": "#52525366"
+          }
+        ],
+        "predictive": "#7b7c7e",
+        "renamed": "#08bdba",
+        "scrollbar.thumb.background": "#52525366",
+        "scrollbar.thumb.hover_background": "#525253CC",
+        "scrollbar.track.background": "#2a2a2a0D",
+        "search.match_background": "#525253CC",
+        "status_bar.background": "#0c0c0cCC",
+        "success": "#25be6a",
+        "success.background": "#182f23",
+        "surface.background": "#0c0c0cCC",
+        "syntax": {
+          "boolean": {
+            "color": "#5ae0df"
+          },
+          "comment": {
+            "color": "#6e6f70"
+          },
+          "comment.doc": {
+            "color": "#6e6f70"
+          },
+          "constant": {
+            "color": "#5ae0df"
+          },
+          "constructor": {
+            "color": "#5ae0df"
+          },
+          "function": {
+            "color": "#8cb6ff"
+          },
+          "keyword": {
+            "color": "#be95ff"
+          },
+          "number": {
+            "color": "#3ddbd9"
+          },
+          "operator": {
+            "color": "#b6b8bb"
+          },
+          "preproc": {
+            "color": "#ff91c1"
+          },
+          "property": {
+            "color": "#78a9ff"
+          },
+          "punctuation": {
+            "color": "#b6b8bb"
+          },
+          "punctuation.bracket": {
+            "color": "#b6b8bb"
+          },
+          "punctuation.delimiter": {
+            "color": "#b6b8bb"
+          },
+          "punctuation.markup": {
+            "color": "#b6b8bb"
+          },
+          "punctuation.special": {
+            "color": "#b6b8bb"
+          },
+          "string": {
+            "color": "#25be6a"
+          },
+          "string.escape": {
+            "color": "#25be6a"
+          },
+          "string.regex": {
+            "color": "#2dc7c4"
+          },
+          "string.special": {
+            "color": "#52bdff"
+          },
+          "string.special.symbol": {
+            "color": "#ee5396"
+          },
+          "tag": {
+            "color": "#a27fd9"
+          },
+          "text.literal": {
+            "color": "#25be6a"
+          },
+          "type": {
+            "color": "#08bdba"
+          },
+          "variable": {
+            "color": "#33b1ff"
+          },
+          "variable.special": {
+            "color": "#ee5396"
+          }
+        },
+        "tab.active_background": "#2a2a2a26",
+        "tab.inactive_background": "#16161626",
+        "tab_bar.background": "#16161626",
+        "terminal.ansi.black": "#282828",
+        "terminal.ansi.blue": "#78a9ff",
+        "terminal.ansi.bright_black": "#484848",
+        "terminal.ansi.bright_blue": "#8cb6ff",
+        "terminal.ansi.bright_cyan": "#52bdff",
+        "terminal.ansi.bright_green": "#46c880",
+        "terminal.ansi.bright_magenta": "#c8a5ff",
+        "terminal.ansi.bright_red": "#f16da6",
+        "terminal.ansi.bright_white": "#e4e4e5",
+        "terminal.ansi.bright_yellow": "#2dc7c4",
+        "terminal.ansi.cyan": "#33b1ff",
+        "terminal.ansi.dim_black": "#222222",
+        "terminal.ansi.dim_blue": "#6690d9",
+        "terminal.ansi.dim_cyan": "#2b96d9",
+        "terminal.ansi.dim_green": "#1fa25a",
+        "terminal.ansi.dim_magenta": "#a27fd9",
+        "terminal.ansi.dim_red": "#ca4780",
+        "terminal.ansi.dim_white": "#bebebe",
+        "terminal.ansi.dim_yellow": "#07a19e",
+        "terminal.ansi.green": "#25be6a",
+        "terminal.ansi.magenta": "#be95ff",
+        "terminal.ansi.red": "#ee5396",
+        "terminal.ansi.white": "#dfdfe0",
+        "terminal.ansi.yellow": "#08bdba",
+        "terminal.background": "#16161600",
+        "terminal.bright_foreground": "#f9fbff",
+        "terminal.dim_foreground": "#b6b8bb",
+        "terminal.foreground": "#f2f4f8",
+        "text": "#f9fbff",
+        "text.accent": "#34bab8",
+        "text.disabled": "#6e6f70",
+        "text.muted": "#f2f4f8",
+        "text.placeholder": "#7b7c7e",
+        "title_bar.background": "#0c0c0cCC",
+        "toolbar.background": "#2a2a2a26",
         "version_control.added": "#25be6a",
         "version_control.conflict": "#3ddbd9",
         "version_control.deleted": "#ee5396",


### PR DESCRIPTION
### What's Changed
- Add BackgroundAppearance type alias for opaque/blurred/transparent modes
- Implement dynamic alpha level system based on appearance mode
- Generate separate theme variants for opaque and blurred appearances
- Refactor _accent_colors to use alpha transparency with configurable values
- Update all color definitions to use appearance-aware alpha levels
- Fix function signature mismatches in _accent_colors call

<img width="500" height="313" alt="carbonfox" src="https://github.com/user-attachments/assets/34635356-1c52-4d86-9c95-e603e8b1fa42" />
<img width="500" height="313" alt="dawnfox" src="https://github.com/user-attachments/assets/454f34b1-70d8-444e-b028-9dee850f9bda" />
<img width="500" height="313" alt="dayfox" src="https://github.com/user-attachments/assets/0de9ba81-aa20-472b-bdca-91f6d95edfa9" />
<img width="500" height="313" alt="duskfox" src="https://github.com/user-attachments/assets/c5442cd7-b938-4014-b48d-a2c1e88e28c7" />
<img width="500" height="313" alt="nightfox" src="https://github.com/user-attachments/assets/c5c979a2-5fb0-4f0c-bbea-3f9ff8b38b8a" />
<img width="500" height="313" alt="nordfox" src="https://github.com/user-attachments/assets/24816d4c-d2a7-45ef-a332-5f6dee5393fd" />
<img width="500" height="313" alt="terafox" src="https://github.com/user-attachments/assets/4ef6cb17-843e-48c0-96db-b9566621b894" />
