### PR TITLE
fix(extension): downgrade unsupported schema version

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "nvim-nightfox"
 name = "Nightfox Themes - opaque / blurred"
 version = "0.5.1"
-schema_version = 2
+schema_version = 1
 authors = ["Christian Angermann"]
 description = "A port of the Neovim Nightfox themes. Includes all variants as opaque and blurred version."
 repository = "https://github.com/cange/nightfox.zed"


### PR DESCRIPTION
Leads to that the theme is no longer listed in the Zed extension.