### PR TITLE
fix: sticky scroll overlay

### DIFF
--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -153,6 +153,7 @@ function M._theme_colors(pal, spec, background_appearance)
     ["title_bar.inactive_background"] = AS_NONE,
     ["toolbar.background"] = alpha(spec.sel0, M._alphas.MID),
     ["panel.background"] = alpha(spec.bg0, M._alphas.LOW),
+    ["panel.overlay_background"] = alpha(spec.bg0, M._alphas.MAX),
     ["panel.focused_border"] = alpha(spec.sel1, M._alphas.MAX),
     ["panel.indent_guide"] = AS_NONE,
     ["panel.indent_guide_active"] = AS_NONE,

--- a/themes/nvim-nightfox.json
+++ b/themes/nvim-nightfox.json
@@ -60,6 +60,7 @@
         "modified": "#dbc074",
         "panel.background": "#131a244D",
         "panel.focused_border": "#3c5372FF",
+        "panel.overlay_background": "#131a24FF",
         "players": [
           {
             "background": "#29394f4D",
@@ -262,6 +263,7 @@
         "modified": "#ac5402",
         "panel.background": "#e4dcd44D",
         "panel.focused_border": "#a4c1c2FF",
+        "panel.overlay_background": "#e4dcd4FF",
         "players": [
           {
             "background": "#d3c7bb4D",
@@ -464,6 +466,7 @@
         "modified": "#ea9d34",
         "panel.background": "#ebe5df4D",
         "panel.focused_border": "#b8ceceFF",
+        "panel.overlay_background": "#ebe5dfFF",
         "players": [
           {
             "background": "#ebdfe44D",
@@ -666,6 +669,7 @@
         "modified": "#f6c177",
         "panel.background": "#1917264D",
         "panel.focused_border": "#63577dFF",
+        "panel.overlay_background": "#191726FF",
         "players": [
           {
             "background": "#3733544D",
@@ -868,6 +872,7 @@
         "modified": "#ebcb8b",
         "panel.background": "#2328314D",
         "panel.focused_border": "#4f6074FF",
+        "panel.overlay_background": "#232831FF",
         "players": [
           {
             "background": "#444c5e4D",
@@ -1070,6 +1075,7 @@
         "modified": "#fda47f",
         "panel.background": "#0f1c1e4D",
         "panel.focused_border": "#425e5eFF",
+        "panel.overlay_background": "#0f1c1eFF",
         "players": [
           {
             "background": "#2541474D",
@@ -1272,6 +1278,7 @@
         "modified": "#08bdba",
         "panel.background": "#0c0c0c4D",
         "panel.focused_border": "#525253FF",
+        "panel.overlay_background": "#0c0c0cFF",
         "players": [
           {
             "background": "#3535354D",
@@ -1474,6 +1481,7 @@
         "modified": "#dbc074",
         "panel.background": "#131a240D",
         "panel.focused_border": "#3c5372CC",
+        "panel.overlay_background": "#131a24CC",
         "players": [
           {
             "background": "#29394f0D",
@@ -1676,6 +1684,7 @@
         "modified": "#ac5402",
         "panel.background": "#e4dcd40D",
         "panel.focused_border": "#a4c1c2CC",
+        "panel.overlay_background": "#e4dcd4CC",
         "players": [
           {
             "background": "#d3c7bb0D",
@@ -1878,6 +1887,7 @@
         "modified": "#ea9d34",
         "panel.background": "#ebe5df0D",
         "panel.focused_border": "#b8ceceCC",
+        "panel.overlay_background": "#ebe5dfCC",
         "players": [
           {
             "background": "#ebdfe40D",
@@ -2080,6 +2090,7 @@
         "modified": "#f6c177",
         "panel.background": "#1917260D",
         "panel.focused_border": "#63577dCC",
+        "panel.overlay_background": "#191726CC",
         "players": [
           {
             "background": "#3733540D",
@@ -2282,6 +2293,7 @@
         "modified": "#ebcb8b",
         "panel.background": "#2328310D",
         "panel.focused_border": "#4f6074CC",
+        "panel.overlay_background": "#232831CC",
         "players": [
           {
             "background": "#444c5e0D",
@@ -2484,6 +2496,7 @@
         "modified": "#fda47f",
         "panel.background": "#0f1c1e0D",
         "panel.focused_border": "#425e5eCC",
+        "panel.overlay_background": "#0f1c1eCC",
         "players": [
           {
             "background": "#2541470D",
@@ -2686,6 +2699,7 @@
         "modified": "#08bdba",
         "panel.background": "#0c0c0c0D",
         "panel.focused_border": "#525253CC",
+        "panel.overlay_background": "#0c0c0cCC",
         "players": [
           {
             "background": "#3535350D",


### PR DESCRIPTION
### Context

With the addition of sticky scroll (see https://github.com/zed-industries/zed/pull/33994) and it being the default, it is hard to read that section because of the transparent background.

### Approach

Use the newly added `panel.overlay_background` (see https://github.com/zed-industries/zed/pull/34655) to define the background color of those items. I went with the same as `panel.background` but with `HIGH` alpha. Tried multiple alpha values, and that was the one that seemed to work better while still have the transparent look. Feel free to suggest any other value.

| Before | After |
| --- | --- |
| <img width="303" height="295" alt="Nightfox - opaque (before)" src="https://github.com/user-attachments/assets/7ebe5326-2928-4959-9594-bd7eae579f49" /> | <img width="300" height="291" alt="Nightfox - opaque (after)" src="https://github.com/user-attachments/assets/a16cdb6f-6a12-4d52-b86f-3dddd55580aa" /> |
| <img width="305" height="292" alt="Dayfox - opaque (before)" src="https://github.com/user-attachments/assets/5c0ed5db-e93d-4017-8484-2b415cb837bf" /> | <img width="307" height="291" alt="Dayfox - opaque (after)" src="https://github.com/user-attachments/assets/321e7380-2c8e-40e8-9fde-2047497829fa" /> |
| <img width="305" height="292" alt="Dawnfox - opaque (before)" src="https://github.com/user-attachments/assets/a4d6d71d-e92f-4069-b2a6-38deaf96bf75" /> | <img width="305" height="290" alt="Dawnfox - opaque (after)" src="https://github.com/user-attachments/assets/80401292-8a67-43ac-962b-da57d03fa475" /> |
| <img width="304" height="289" alt="Duskfox - opaque (before)" src="https://github.com/user-attachments/assets/fba61e43-e472-4ff1-a94a-5d45db9f26b8" /> | <img width="303" height="292" alt="Duskfox - opaque (after)" src="https://github.com/user-attachments/assets/0d345975-f489-4afd-929b-804dc192ecef" /> |
| <img width="307" height="292" alt="Nordfox - opaque (before)" src="https://github.com/user-attachments/assets/f76890a5-ba6c-4de0-928f-58d077d3a19c" /> | <img width="303" height="291" alt="Nordfox - opaque (after)" src="https://github.com/user-attachments/assets/90e31f2b-f7c9-4f06-bd45-97f0ce3a5774" /> |
| <img width="303" height="289" alt="Terafox - opaque (before)" src="https://github.com/user-attachments/assets/8860108a-67aa-4e25-9091-ad406913c089" /> | <img width="303" height="290" alt="Terafox - opaque (after)" src="https://github.com/user-attachments/assets/97db4105-d125-4534-b48c-adf00353ee4f" /> |
| <img width="303" height="294" alt="Carbonfox - opaque (before)" src="https://github.com/user-attachments/assets/8bbd1e7d-fec2-4d43-a597-6cb60047ce81" /> | <img width="303" height="290" alt="Carbonfox - opaque (after)" src="https://github.com/user-attachments/assets/e1d0cab0-5800-474a-bdc4-9a9f7e7c1641" /> |