### PR TITLE
feat(syntax): improve language key support

### DIFF
--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -324,12 +324,11 @@ function M._syntax_theme(pal, spec)
     ["variable.special"] = m({ color = spec.syntax.builtin0 }),
     ["variable.parameter"] = m({ color = todo.yellow.base }), -- function/method parameters
     -- Punctuation
-    ["punctuation"] = m({ color = spec.syntax.bracket }),
+    ["punctuation"] = m({ color = spec.syntax.operator }),
     ["punctuation.bracket"] = m({ color = spec.syntax.bracket }),
-    ["punctuation.delimiter"] = m({ color = spec.syntax.bracket }),
+    ["punctuation.delimiter"] = AS_NONE,
     ["punctuation.list_marker"] = m({ color = spec.syntax.builtin1 }),
-    ["punctuation.markup"] = m({ color = spec.syntax.bracket }),
-    ["punctuation.special"] = m({ color = spec.syntax.bracket }),
+    ["punctuation.special"] = m({ color = spec.syntax.builtin1 }),
     -- Markup
     ["tag"] = m({ color = pal.magenta.base }),
     ["tag.doctype"] = m({ color = spec.syntax.const }), -- doctypes (e.g., in HTML)

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -294,9 +294,7 @@ function M._syntax_theme(pal, spec)
     -- Strings & Literal
     ["string"] = m({ color = spec.syntax.string }),
     ["string.doc"] = AS_NONE, -- e.g. python
-    ["string.escape"] = m({ color = pal.green.base }),
-    ["string.regex"] = m({ color = spec.syntax.regex }),
-    ["string.special"] = m({ color = spec.syntax.builtin1 }),
+    ["string.special"] = m({ color = spec.syntax.builtin1 }), -- e.g. javascript, tsx
     ["string.special.path"] = AS_NONE, -- e.g. gitcommit
     ["string.special.symbol"] = AS_NONE, -- e.g. gitcommit
     ["text.literal"] = m({ color = pal.green.base }),
@@ -313,7 +311,6 @@ function M._syntax_theme(pal, spec)
     ["keyword.jsdoc"] = AS_NONE,
     ["keyword.modifier"] = AS_NONE,
     ["keyword.operator"] = m({ color = spec.syntax.operator }),
-    ["keyword.operator.regex"] = AS_NONE,
     ["keyword.preproc"] = AS_NONE,
     operator = m({ color = spec.syntax.operator }),
     preproc = m({ color = spec.syntax.preproc }),
@@ -403,6 +400,16 @@ function M._syntax_theme(pal, spec)
     ["text.literal.markup"] = m({ color = spec.syntax.builtin1 }), -- e.g. markdown-inline
     ["text.markup"] = AS_NONE, -- e.g. markdown
     ["title.markup"] = AS_NONE, -- e.g. markdown
+    -- special: regex
+    ["keyword.operator.regex"] = m({ color = spec.syntax.func }), -- e.g. regex, typescript, javascript, jsx
+    ["label.regex"] = m({ color = spec.syntax.regex }), -- e.g. regex
+    ["number.quantifier.regex"] = AS_NONE, -- e.g. regex
+    ["operator.regex"] = AS_NONE, -- e.g. regex
+    ["punctuation.bracket.regex"] = AS_NONE, -- e.g. regex
+    ["punctuation.delimiter.regex"] = AS_NONE, -- e.g. regex
+    ["string.escape"] = m({ color = spec.syntax.builtin2 }), -- e.g. regex
+    ["string.escape.regex"] = AS_NONE, -- e.g. regex
+    ["string.regex"] = m({ color = spec.syntax.regex }),
     -- Other
     primary = m({ color = AS_UNUSED }), -- primary elements
     embedded = m({ color = spec.fg1 }), -- embedded content

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -335,8 +335,10 @@ function M._syntax_theme(pal, spec)
     namespace = m({ color = todo.blue.base }),
     variant = m({ color = todo.green.base }),
     -- Variables & Properties
+    ["property"] = m({ color = spec.syntax.field }),
+    ["property.json_key"] = AS_NONE,
+    ["property.name"] = AS_NONE,
     label = m({ color = todo.magenta.base }),
-    property = m({ color = pal.blue.base }),
     ["variable"] = m({ color = spec.syntax.variable }),
     ["variable.builtin"] = AS_NONE,
     ["variable.other.member"] = AS_NONE, -- e.g. gitcommit

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -337,9 +337,11 @@ function M._syntax_theme(pal, spec)
     -- Variables & Properties
     label = m({ color = todo.magenta.base }),
     property = m({ color = pal.blue.base }),
-    ["variable"] = m({ color = pal.cyan.base }),
+    ["variable"] = m({ color = spec.syntax.variable }),
+    ["variable.builtin"] = AS_NONE,
+    ["variable.other.member"] = AS_NONE, -- e.g. gitcommit
+    ["variable.parameter"] = m({ color = spec.syntax.ident }), -- function/method parameters
     ["variable.special"] = m({ color = spec.syntax.builtin0 }),
-    ["variable.parameter"] = m({ color = todo.yellow.base }), -- function/method parameters
     -- Punctuation
     ["punctuation"] = m({ color = spec.syntax.operator }),
     ["punctuation.bracket"] = m({ color = spec.syntax.bracket }),

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -303,7 +303,7 @@ function M._syntax_theme(pal, spec)
     -- Numbers & Constants
     boolean = m({ color = spec.syntax.const }),
     ["constant"] = m({ color = spec.syntax.const }),
-    ["constant.builtin"] = m({ color = todo.red.base }),
+    ["constant.builtin"] = m({ color = spec.syntax.builtin2 }),
     number = m({ color = spec.syntax.number }),
     -- Keywords & Operators
     ["keyword"] = m({ color = spec.syntax.keyword }),

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -318,7 +318,14 @@ function M._syntax_theme(pal, spec)
     operator = m({ color = spec.syntax.operator }),
     preproc = m({ color = spec.syntax.preproc }),
     -- Functions & Methods
-    attribute = m({ color = spec.syntax.field }),
+    ["attribute"] = m({
+      color = spec.syntax.field,
+      font_style = "italic",
+    }),
+    ["attribute.builtin"] = m({
+      color = spec.syntax.const,
+      font_style = "normal",
+    }), -- e.g. python
     constructor = m({ color = spec.syntax.builtin2 }),
     ["function"] = m({ color = spec.syntax.func }),
     -- Types & Classes

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -330,10 +330,17 @@ function M._syntax_theme(pal, spec)
     ["function"] = m({ color = spec.syntax.func }),
     -- Types & Classes
     ["type"] = m({ color = spec.syntax.type }),
-    ["type.builtin"] = m({ color = todo.blue.base }),
-    enum = m({ color = todo.red.base }),
-    namespace = m({ color = todo.blue.base }),
-    variant = m({ color = todo.green.base }),
+    ["type.builtin"] = AS_NONE,
+    ["type.class"] = AS_NONE,
+    ["type.class.call"] = m({ color = spec.syntax.ident }), -- e.g. python
+    ["type.class.definition"] = AS_NONE, -- e.g. python
+    ["type.class.inheritance"] = m({ color = spec.syntax.ident }), -- e.g. python
+    ["type.definition"] = AS_NONE,
+    ["type.interface"] = AS_NONE, -- e.g. rust
+    ["type.name"] = AS_NONE, -- e.g. typescript
+    enum = AS_UNUSED,
+    namespace = AS_UNUSED,
+    variant = AS_UNUSED,
     -- Variables & Properties
     ["property"] = m({ color = spec.syntax.field }),
     ["property.json_key"] = AS_NONE,

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -293,10 +293,12 @@ function M._syntax_theme(pal, spec)
     ["comment.doc"] = m({ color = spec.syntax.comment }),
     -- Strings & Literal
     ["string"] = m({ color = spec.syntax.string }),
+    ["string.doc"] = AS_NONE, -- e.g. python
     ["string.escape"] = m({ color = pal.green.base }),
     ["string.regex"] = m({ color = spec.syntax.regex }),
     ["string.special"] = m({ color = spec.syntax.builtin1 }),
-    ["string.special.symbol"] = m({ color = spec.syntax.builtin0 }),
+    ["string.special.path"] = AS_NONE, -- e.g. gitcommit
+    ["string.special.symbol"] = AS_NONE, -- e.g. gitcommit
     ["text.literal"] = m({ color = pal.green.base }),
     -- Numbers & Constants
     boolean = m({ color = spec.syntax.const }),

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -307,6 +307,7 @@ function M._syntax_theme(pal, spec)
     ["keyword"] = m({ color = spec.syntax.keyword }),
     ["keyword.control"] = AS_NONE,
     ["keyword.declaration"] = AS_NONE,
+    ["keyword.directive"] = m({ color = spec.syntax.func }), -- e.g. jsx
     ["keyword.import"] = m({ color = spec.syntax.preproc }),
     ["keyword.jsdoc"] = AS_NONE,
     ["keyword.modifier"] = AS_NONE,
@@ -400,6 +401,13 @@ function M._syntax_theme(pal, spec)
     ["text.literal.markup"] = m({ color = spec.syntax.builtin1 }), -- e.g. markdown-inline
     ["text.markup"] = AS_NONE, -- e.g. markdown
     ["title.markup"] = AS_NONE, -- e.g. markdown
+    -- special: jsx
+    ["attribute.jsx"] = AS_NONE,
+    ["punctuation.bracket.jsx"] = m({ color = spec.syntax.builtin1 }), -- e.g. javascript, tsx
+    ["punctuation.delimiter.jsx"] = AS_NONE, -- e.g. tsx
+    ["tag.component.jsx"] = m({ color = spec.syntax.func }), -- e.g. javascript, tsx
+    ["tag.jsx"] = AS_NONE,
+    ["text.jsx"] = AS_NONE,
     -- special: regex
     ["keyword.operator.regex"] = m({ color = spec.syntax.func }), -- e.g. regex, typescript, javascript, jsx
     ["label.regex"] = m({ color = spec.syntax.regex }), -- e.g. regex

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -283,6 +283,7 @@ end
 ---@param spec nightfox_nvim.Spec
 ---@return table<string, nightfox_zed.HighlightStyle>
 ---See: https://github.com/zed-industries/zed/blob/main/crates/theme/src/fallback_themes.rs
+---See: https://zed.dev/docs/extensions/languages#syntax-highlighting
 function M._syntax_theme(pal, spec)
   local todo = util.color.debug
   local m = M._syntax_theme_merge
@@ -299,7 +300,8 @@ function M._syntax_theme(pal, spec)
     ["text.literal"] = m({ color = pal.green.base }),
     -- Numbers & Constants
     boolean = m({ color = spec.syntax.const }),
-    constant = m({ color = spec.syntax.const }),
+    ["constant"] = m({ color = spec.syntax.const }),
+    ["constant.builtin"] = m({ color = todo.red.base }),
     number = m({ color = spec.syntax.number }),
     -- Keywords & Operators
     keyword = m({ color = spec.syntax.keyword }),
@@ -310,7 +312,8 @@ function M._syntax_theme(pal, spec)
     constructor = m({ color = spec.syntax.builtin2 }),
     ["function"] = m({ color = spec.syntax.func }),
     -- Types & Classes
-    type = m({ color = spec.syntax.type }),
+    ["type"] = m({ color = spec.syntax.type }),
+    ["type.builtin"] = m({ color = todo.blue.base }),
     enum = m({ color = todo.red.base }),
     namespace = m({ color = todo.blue.base }),
     variant = m({ color = todo.green.base }),
@@ -319,6 +322,7 @@ function M._syntax_theme(pal, spec)
     property = m({ color = pal.blue.base }),
     ["variable"] = m({ color = pal.cyan.base }),
     ["variable.special"] = m({ color = spec.syntax.builtin0 }),
+    ["variable.parameter"] = m({ color = todo.yellow.base }), -- function/method parameters
     -- Punctuation
     ["punctuation"] = m({ color = spec.syntax.bracket }),
     ["punctuation.bracket"] = m({ color = spec.syntax.bracket }),

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -350,11 +350,8 @@ function M._syntax_theme(pal, spec)
       color = spec.syntax.builtin2,
       font_style = "italic",
     }),
-    ["selector"] = m({ color = todo.cyan.base }),
-    ["selector.pseudo"] = m({
-      color = todo.cyan.base,
-      font_style = "italic",
-    }),
+    ["selector"] = m({ color = spec.syntax.type }),
+    ["selector.pseudo"] = m({ color = spec.syntax.const }),
     -- Other
     primary = m({ color = AS_UNUSED }), -- primary elements
     embedded = m({ color = spec.fg1 }), -- embedded content

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -331,7 +331,8 @@ function M._syntax_theme(pal, spec)
     ["punctuation.markup"] = m({ color = spec.syntax.bracket }),
     ["punctuation.special"] = m({ color = spec.syntax.bracket }),
     -- Markup
-    tag = m({ color = pal.magenta.dim }),
+    ["tag"] = m({ color = pal.magenta.base }),
+    ["tag.doctype"] = m({ color = spec.syntax.const }), -- doctypes (e.g., in HTML)
     title = m({
       color = spec.syntax.func,
       font_weight = 700,

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -285,7 +285,6 @@ end
 ---See: https://github.com/zed-industries/zed/blob/main/crates/theme/src/fallback_themes.rs
 ---See: https://zed.dev/docs/extensions/languages#syntax-highlighting
 function M._syntax_theme(pal, spec)
-  local todo = util.color.debug
   local m = M._syntax_theme_merge
   return {
     -- Comments & Docs
@@ -297,7 +296,7 @@ function M._syntax_theme(pal, spec)
     ["string.special"] = m({ color = spec.syntax.builtin1 }), -- e.g. javascript, tsx
     ["string.special.path"] = AS_NONE, -- e.g. gitcommit
     ["string.special.symbol"] = AS_NONE, -- e.g. gitcommit
-    ["text.literal"] = m({ color = pal.green.base }),
+    ["text.literal"] = AS_UNUSED,
     -- Numbers & Constants
     boolean = m({ color = spec.syntax.const }),
     ["constant"] = m({ color = spec.syntax.const }),
@@ -324,7 +323,7 @@ function M._syntax_theme(pal, spec)
       color = spec.syntax.const,
       font_style = "normal",
     }), -- e.g. python
-    constructor = m({ color = spec.syntax.builtin2 }),
+    constructor = m({ color = spec.syntax.ident }),
     ["function"] = m({ color = spec.syntax.func }),
     ["function.builtin"] = m({ color = spec.syntax.builtin0 }),
     ["function.call"] = AS_NONE, -- e.g. cpp, python, go
@@ -350,10 +349,10 @@ function M._syntax_theme(pal, spec)
     namespace = m({ color = spec.syntax.builtin1 }), -- e.g. css, go, cpp
     variant = AS_UNUSED,
     -- Variables & Properties
+    label = AS_NONE, -- e.g. c, diff, go, cpp, regex
     ["property"] = m({ color = spec.syntax.field }),
     ["property.json_key"] = AS_NONE,
     ["property.name"] = AS_NONE,
-    label = m({ color = todo.magenta.base }),
     ["variable"] = m({ color = spec.syntax.variable }),
     ["variable.builtin"] = AS_NONE,
     ["variable.other.member"] = AS_NONE, -- e.g. gitcommit
@@ -419,10 +418,10 @@ function M._syntax_theme(pal, spec)
     ["string.escape.regex"] = AS_NONE, -- e.g. regex
     ["string.regex"] = m({ color = spec.syntax.regex }),
     -- Other
-    primary = m({ color = AS_UNUSED }), -- primary elements
     embedded = m({ color = spec.fg1 }), -- embedded content
-    predictive = m({ color = AS_UNUSED }), --  predictive text
-    hint = m({ color = AS_UNUSED }), -- hints
+    hint = AS_UNUSED, -- hints
+    predictive = AS_UNUSED, --  predictive text
+    primary = AS_UNUSED, -- primary elements
   }
 end
 

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -344,11 +344,11 @@ function M._syntax_theme(pal, spec)
       color = pal.red.base,
       font_weight = 700,
     }),
-    link_text = m({
-      color = pal.yellow.base,
-      font_style = "underline",
+    link_text = m({ color = spec.syntax.func }),
+    link_uri = m({
+      color = spec.syntax.builtin2,
+      font_style = "italic",
     }),
-    link_uri = m({ color = spec.syntax.const }),
     ["selector"] = m({ color = todo.cyan.base }),
     ["selector.pseudo"] = m({
       color = todo.cyan.base,

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -347,7 +347,7 @@ function M._syntax_theme(pal, spec)
     ["type.interface"] = AS_NONE, -- e.g. rust
     ["type.name"] = AS_NONE, -- e.g. typescript
     enum = AS_UNUSED,
-    namespace = AS_UNUSED,
+    namespace = m({ color = spec.syntax.builtin1 }), -- e.g. css, go, cpp
     variant = AS_UNUSED,
     -- Variables & Properties
     ["property"] = m({ color = spec.syntax.field }),

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -328,6 +328,16 @@ function M._syntax_theme(pal, spec)
     }), -- e.g. python
     constructor = m({ color = spec.syntax.builtin2 }),
     ["function"] = m({ color = spec.syntax.func }),
+    ["function.builtin"] = m({ color = spec.syntax.builtin0 }),
+    ["function.call"] = AS_NONE, -- e.g. cpp, python, go
+    ["function.decorator"] = m({ color = spec.syntax.const }), -- e.g. python
+    ["function.decorator.call"] = AS_NONE, -- e.g. python
+    ["function.definition"] = AS_NONE,
+    ["function.kwargs"] = m({ color = spec.syntax.ident }), -- e.g. python
+    ["function.method"] = AS_NONE,
+    ["function.method.call"] = AS_NONE, -- e.g. python, go
+    ["function.method.constructor"] = m({ color = spec.syntax.ident }), -- e.g. python
+    ["function.special"] = m({ color = spec.syntax.builtin0 }),
     -- Types & Classes
     ["type"] = m({ color = spec.syntax.type }),
     ["type.builtin"] = AS_NONE,

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -368,18 +368,18 @@ function M._syntax_theme(pal, spec)
     ["punctuation.list_marker"] = m({ color = spec.syntax.builtin1 }),
     ["punctuation.special"] = m({ color = spec.syntax.builtin1 }),
     -- Markup
-    ["tag"] = m({ color = pal.magenta.base }),
+    ["tag"] = m({ color = spec.syntax.keyword }),
     ["tag.doctype"] = m({ color = spec.syntax.const }), -- doctypes (e.g., in HTML)
     title = m({
       color = spec.syntax.func,
       font_weight = 700,
     }),
     ["emphasis"] = m({
-      color = spec.fg1,
+      color = spec.syntax.builtin0,
       font_style = "italic",
     }),
     ["emphasis.strong"] = m({
-      color = pal.red.base,
+      color = spec.syntax.builtin0,
       font_weight = 700,
     }),
     link_text = m({ color = spec.syntax.func }),
@@ -389,6 +389,20 @@ function M._syntax_theme(pal, spec)
     }),
     ["selector"] = m({ color = spec.syntax.type }),
     ["selector.pseudo"] = m({ color = spec.syntax.const }),
+    -- special: markup
+    ["emphasis.markup"] = AS_NONE, -- e.g. markdown-inline
+    ["emphasis.strong.markup"] = AS_NONE, -- e.g. markdown-inline
+    ["link_text.markup"] = AS_NONE, -- e.g. markdown, markdown-inline
+    ["link_uri.markup"] = AS_NONE, -- e.g. markdown, markdown-inline
+    ["markup.heading"] = AS_NONE, -- e.g. gitcommit
+    ["markup.link_uri"] = AS_NONE, -- e.g. gitcommit
+    ["punctuation.embedded.markup"] = m({ color = spec.syntax.keyword }), -- e.g. markdown
+    ["punctuation.list_marker.markup"] = AS_NONE, -- e.g. markdown
+    ["punctuation.markup"] = m({ color = spec.syntax.keyword }), -- e.g. markdown
+    ["strikethrough.markup"] = m({ color = spec.syntax.builtin1 }), -- e.g. markdown-inline
+    ["text.literal.markup"] = m({ color = spec.syntax.builtin1 }), -- e.g. markdown-inline
+    ["text.markup"] = AS_NONE, -- e.g. markdown
+    ["title.markup"] = AS_NONE, -- e.g. markdown
     -- Other
     primary = m({ color = AS_UNUSED }), -- primary elements
     embedded = m({ color = spec.fg1 }), -- embedded content

--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -304,7 +304,15 @@ function M._syntax_theme(pal, spec)
     ["constant.builtin"] = m({ color = todo.red.base }),
     number = m({ color = spec.syntax.number }),
     -- Keywords & Operators
-    keyword = m({ color = spec.syntax.keyword }),
+    ["keyword"] = m({ color = spec.syntax.keyword }),
+    ["keyword.control"] = AS_NONE,
+    ["keyword.declaration"] = AS_NONE,
+    ["keyword.import"] = m({ color = spec.syntax.preproc }),
+    ["keyword.jsdoc"] = AS_NONE,
+    ["keyword.modifier"] = AS_NONE,
+    ["keyword.operator"] = m({ color = spec.syntax.operator }),
+    ["keyword.operator.regex"] = AS_NONE,
+    ["keyword.preproc"] = AS_NONE,
     operator = m({ color = spec.syntax.operator }),
     preproc = m({ color = spec.syntax.preproc }),
     -- Functions & Methods

--- a/themes/nvim-nightfox.json
+++ b/themes/nvim-nightfox.json
@@ -125,7 +125,12 @@
         "surface.background": "#131a24FF",
         "syntax": {
           "attribute": {
-            "color": "#719cd6"
+            "color": "#719cd6",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#f6b079",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#f6b079"
@@ -139,42 +144,68 @@
           "constant": {
             "color": "#f6b079"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#f6b079"
+          },
+          "constructor": {
+            "color": "#63cdcf"
           },
           "embedded": {
             "color": "#cdcecf"
           },
           "emphasis": {
-            "color": "#cdcecf",
+            "color": "#c94f6d",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#c94f6d",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#86abdc"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#c94f6d"
+          },
+          "function.decorator": {
+            "color": "#f6b079"
+          },
+          "function.kwargs": {
+            "color": "#63cdcf"
+          },
+          "function.method.constructor": {
+            "color": "#63cdcf"
+          },
+          "function.special": {
+            "color": "#c94f6d"
+          },
           "keyword": {
             "color": "#9d79d6"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#86abdc"
+          },
+          "keyword.import": {
+            "color": "#dc8ed9"
+          },
+          "keyword.operator": {
+            "color": "#aeafb0"
+          },
+          "keyword.operator.regex": {
+            "color": "#86abdc"
+          },
+          "label.regex": {
+            "color": "#e0c989"
           },
           "link_text": {
-            "color": "#dbc074",
-            "font_style": "underline"
+            "color": "#86abdc"
           },
           "link_uri": {
-            "color": "#f6b079"
+            "color": "#f6b079",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#7ad5d6"
           },
           "number": {
             "color": "#f4a261"
@@ -182,11 +213,9 @@
           "operator": {
             "color": "#aeafb0"
           },
-          "predictive": [],
           "preproc": {
             "color": "#dc8ed9"
           },
-          "primary": [],
           "property": {
             "color": "#719cd6"
           },
@@ -196,30 +225,35 @@
           "punctuation.bracket": {
             "color": "#aeafb0"
           },
-          "punctuation.delimiter": {
-            "color": "#aeafb0"
+          "punctuation.bracket.jsx": {
+            "color": "#7ad5d6"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#9d79d6"
           },
           "punctuation.list_marker": {
             "color": "#7ad5d6"
           },
           "punctuation.markup": {
-            "color": "#aeafb0"
+            "color": "#9d79d6"
           },
           "punctuation.special": {
-            "color": "#aeafb0"
+            "color": "#7ad5d6"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#dbc074"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#f6b079"
+          },
+          "strikethrough.markup": {
+            "color": "#7ad5d6"
           },
           "string": {
             "color": "#81b29a"
           },
           "string.escape": {
-            "color": "#81b29a"
+            "color": "#f6b079"
           },
           "string.regex": {
             "color": "#e0c989"
@@ -227,14 +261,17 @@
           "string.special": {
             "color": "#7ad5d6"
           },
-          "string.special.symbol": {
-            "color": "#c94f6d"
-          },
           "tag": {
-            "color": "#8567b6"
+            "color": "#9d79d6"
           },
-          "text.literal": {
-            "color": "#81b29a"
+          "tag.component.jsx": {
+            "color": "#86abdc"
+          },
+          "tag.doctype": {
+            "color": "#f6b079"
+          },
+          "text.literal.markup": {
+            "color": "#7ad5d6"
           },
           "title": {
             "color": "#86abdc",
@@ -243,14 +280,20 @@
           "type": {
             "color": "#dbc074"
           },
+          "type.class.call": {
+            "color": "#63cdcf"
+          },
+          "type.class.inheritance": {
+            "color": "#63cdcf"
+          },
           "variable": {
+            "color": "#dfdfe0"
+          },
+          "variable.parameter": {
             "color": "#63cdcf"
           },
           "variable.special": {
             "color": "#c94f6d"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#2b3b518C",
@@ -442,7 +485,12 @@
         "surface.background": "#e4dcd4FF",
         "syntax": {
           "attribute": {
-            "color": "#2848a9"
+            "color": "#2848a9",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#7f5152",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#7f5152"
@@ -456,42 +504,68 @@
           "constant": {
             "color": "#7f5152"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#7f5152"
+          },
+          "constructor": {
+            "color": "#287980"
           },
           "embedded": {
             "color": "#3d2b5a"
           },
           "emphasis": {
-            "color": "#3d2b5a",
+            "color": "#a5222f",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#a5222f",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#223d90"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#a5222f"
+          },
+          "function.decorator": {
+            "color": "#7f5152"
+          },
+          "function.kwargs": {
+            "color": "#287980"
+          },
+          "function.method.constructor": {
+            "color": "#287980"
+          },
+          "function.special": {
+            "color": "#a5222f"
+          },
           "keyword": {
             "color": "#6e33ce"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#223d90"
+          },
+          "keyword.import": {
+            "color": "#8b369a"
+          },
+          "keyword.operator": {
+            "color": "#643f61"
+          },
+          "keyword.operator.regex": {
+            "color": "#223d90"
+          },
+          "label.regex": {
+            "color": "#924702"
           },
           "link_text": {
-            "color": "#ac5402",
-            "font_style": "underline"
+            "color": "#223d90"
           },
           "link_uri": {
-            "color": "#7f5152"
+            "color": "#7f5152",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#22676d"
           },
           "number": {
             "color": "#955f61"
@@ -499,11 +573,9 @@
           "operator": {
             "color": "#643f61"
           },
-          "predictive": [],
           "preproc": {
             "color": "#8b369a"
           },
-          "primary": [],
           "property": {
             "color": "#2848a9"
           },
@@ -513,30 +585,35 @@
           "punctuation.bracket": {
             "color": "#643f61"
           },
-          "punctuation.delimiter": {
-            "color": "#643f61"
+          "punctuation.bracket.jsx": {
+            "color": "#22676d"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#6e33ce"
           },
           "punctuation.list_marker": {
             "color": "#22676d"
           },
           "punctuation.markup": {
-            "color": "#643f61"
+            "color": "#6e33ce"
           },
           "punctuation.special": {
-            "color": "#643f61"
+            "color": "#22676d"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#ac5402"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#7f5152"
+          },
+          "strikethrough.markup": {
+            "color": "#22676d"
           },
           "string": {
             "color": "#396847"
           },
           "string.escape": {
-            "color": "#396847"
+            "color": "#7f5152"
           },
           "string.regex": {
             "color": "#924702"
@@ -544,14 +621,17 @@
           "string.special": {
             "color": "#22676d"
           },
-          "string.special.symbol": {
-            "color": "#a5222f"
-          },
           "tag": {
-            "color": "#5e2baf"
+            "color": "#6e33ce"
           },
-          "text.literal": {
-            "color": "#396847"
+          "tag.component.jsx": {
+            "color": "#223d90"
+          },
+          "tag.doctype": {
+            "color": "#7f5152"
+          },
+          "text.literal.markup": {
+            "color": "#22676d"
           },
           "title": {
             "color": "#223d90",
@@ -560,14 +640,20 @@
           "type": {
             "color": "#ac5402"
           },
+          "type.class.call": {
+            "color": "#287980"
+          },
+          "type.class.inheritance": {
+            "color": "#287980"
+          },
           "variable": {
+            "color": "#352c24"
+          },
+          "variable.parameter": {
             "color": "#287980"
           },
           "variable.special": {
             "color": "#a5222f"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#e7d2be8C",
@@ -759,7 +845,12 @@
         "surface.background": "#ebe5dfFF",
         "syntax": {
           "attribute": {
-            "color": "#286983"
+            "color": "#286983",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#ca6e69",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#ca6e69"
@@ -773,42 +864,68 @@
           "constant": {
             "color": "#ca6e69"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#ca6e69"
+          },
+          "constructor": {
+            "color": "#56949f"
           },
           "embedded": {
             "color": "#575279"
           },
           "emphasis": {
-            "color": "#575279",
+            "color": "#b4637a",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#b4637a",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#295e73"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#b4637a"
+          },
+          "function.decorator": {
+            "color": "#ca6e69"
+          },
+          "function.kwargs": {
+            "color": "#56949f"
+          },
+          "function.method.constructor": {
+            "color": "#56949f"
+          },
+          "function.special": {
+            "color": "#b4637a"
+          },
           "keyword": {
             "color": "#907aa9"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#295e73"
+          },
+          "keyword.import": {
+            "color": "#c9709e"
+          },
+          "keyword.operator": {
+            "color": "#625c87"
+          },
+          "keyword.operator.regex": {
+            "color": "#295e73"
+          },
+          "label.regex": {
+            "color": "#dd9024"
           },
           "link_text": {
-            "color": "#ea9d34",
-            "font_style": "underline"
+            "color": "#295e73"
           },
           "link_uri": {
-            "color": "#ca6e69"
+            "color": "#ca6e69",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#50848c"
           },
           "number": {
             "color": "#d7827e"
@@ -816,11 +933,9 @@
           "operator": {
             "color": "#625c87"
           },
-          "predictive": [],
           "preproc": {
             "color": "#c9709e"
           },
-          "primary": [],
           "property": {
             "color": "#286983"
           },
@@ -830,30 +945,35 @@
           "punctuation.bracket": {
             "color": "#625c87"
           },
-          "punctuation.delimiter": {
-            "color": "#625c87"
+          "punctuation.bracket.jsx": {
+            "color": "#50848c"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#907aa9"
           },
           "punctuation.list_marker": {
             "color": "#50848c"
           },
           "punctuation.markup": {
-            "color": "#625c87"
+            "color": "#907aa9"
           },
           "punctuation.special": {
-            "color": "#625c87"
+            "color": "#50848c"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#ea9d34"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#ca6e69"
+          },
+          "strikethrough.markup": {
+            "color": "#50848c"
           },
           "string": {
             "color": "#618774"
           },
           "string.escape": {
-            "color": "#618774"
+            "color": "#ca6e69"
           },
           "string.regex": {
             "color": "#dd9024"
@@ -861,14 +981,17 @@
           "string.special": {
             "color": "#50848c"
           },
-          "string.special.symbol": {
-            "color": "#b4637a"
-          },
           "tag": {
-            "color": "#816b9a"
+            "color": "#907aa9"
           },
-          "text.literal": {
-            "color": "#618774"
+          "tag.component.jsx": {
+            "color": "#295e73"
+          },
+          "tag.doctype": {
+            "color": "#ca6e69"
+          },
+          "text.literal.markup": {
+            "color": "#50848c"
           },
           "title": {
             "color": "#295e73",
@@ -877,14 +1000,20 @@
           "type": {
             "color": "#ea9d34"
           },
+          "type.class.call": {
+            "color": "#56949f"
+          },
+          "type.class.inheritance": {
+            "color": "#56949f"
+          },
           "variable": {
+            "color": "#575279"
+          },
+          "variable.parameter": {
             "color": "#56949f"
           },
           "variable.special": {
             "color": "#b4637a"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#d0d8d88C",
@@ -1076,7 +1205,12 @@
         "surface.background": "#191726FF",
         "syntax": {
           "attribute": {
-            "color": "#569fba"
+            "color": "#569fba",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#f0a4a2",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#f0a4a2"
@@ -1090,42 +1224,68 @@
           "constant": {
             "color": "#f0a4a2"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#f0a4a2"
+          },
+          "constructor": {
+            "color": "#9ccfd8"
           },
           "embedded": {
             "color": "#e0def4"
           },
           "emphasis": {
-            "color": "#e0def4",
+            "color": "#eb6f92",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#eb6f92",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#65b1cd"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#eb6f92"
+          },
+          "function.decorator": {
+            "color": "#f0a4a2"
+          },
+          "function.kwargs": {
+            "color": "#9ccfd8"
+          },
+          "function.method.constructor": {
+            "color": "#9ccfd8"
+          },
+          "function.special": {
+            "color": "#eb6f92"
+          },
           "keyword": {
             "color": "#c4a7e7"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#65b1cd"
+          },
+          "keyword.import": {
+            "color": "#f0a6cc"
+          },
+          "keyword.operator": {
+            "color": "#cdcbe0"
+          },
+          "keyword.operator.regex": {
+            "color": "#65b1cd"
+          },
+          "label.regex": {
+            "color": "#f9cb8c"
           },
           "link_text": {
-            "color": "#f6c177",
-            "font_style": "underline"
+            "color": "#65b1cd"
           },
           "link_uri": {
-            "color": "#f0a4a2"
+            "color": "#f0a4a2",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#a6dae3"
           },
           "number": {
             "color": "#ea9a97"
@@ -1133,11 +1293,9 @@
           "operator": {
             "color": "#cdcbe0"
           },
-          "predictive": [],
           "preproc": {
             "color": "#f0a6cc"
           },
-          "primary": [],
           "property": {
             "color": "#569fba"
           },
@@ -1147,30 +1305,35 @@
           "punctuation.bracket": {
             "color": "#cdcbe0"
           },
-          "punctuation.delimiter": {
-            "color": "#cdcbe0"
+          "punctuation.bracket.jsx": {
+            "color": "#a6dae3"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#c4a7e7"
           },
           "punctuation.list_marker": {
             "color": "#a6dae3"
           },
           "punctuation.markup": {
-            "color": "#cdcbe0"
+            "color": "#c4a7e7"
           },
           "punctuation.special": {
-            "color": "#cdcbe0"
+            "color": "#a6dae3"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#f6c177"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#f0a4a2"
+          },
+          "strikethrough.markup": {
+            "color": "#a6dae3"
           },
           "string": {
             "color": "#a3be8c"
           },
           "string.escape": {
-            "color": "#a3be8c"
+            "color": "#f0a4a2"
           },
           "string.regex": {
             "color": "#f9cb8c"
@@ -1178,14 +1341,17 @@
           "string.special": {
             "color": "#a6dae3"
           },
-          "string.special.symbol": {
-            "color": "#eb6f92"
-          },
           "tag": {
-            "color": "#a580d2"
+            "color": "#c4a7e7"
           },
-          "text.literal": {
-            "color": "#a3be8c"
+          "tag.component.jsx": {
+            "color": "#65b1cd"
+          },
+          "tag.doctype": {
+            "color": "#f0a4a2"
+          },
+          "text.literal.markup": {
+            "color": "#a6dae3"
           },
           "title": {
             "color": "#65b1cd",
@@ -1194,14 +1360,20 @@
           "type": {
             "color": "#f6c177"
           },
+          "type.class.call": {
+            "color": "#9ccfd8"
+          },
+          "type.class.inheritance": {
+            "color": "#9ccfd8"
+          },
           "variable": {
+            "color": "#e0def4"
+          },
+          "variable.parameter": {
             "color": "#9ccfd8"
           },
           "variable.special": {
             "color": "#eb6f92"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#433c598C",
@@ -1393,7 +1565,12 @@
         "surface.background": "#232831FF",
         "syntax": {
           "attribute": {
-            "color": "#81a1c1"
+            "color": "#81a1c1",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#d89079",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#d89079"
@@ -1407,42 +1584,68 @@
           "constant": {
             "color": "#d89079"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#d89079"
+          },
+          "constructor": {
+            "color": "#88c0d0"
           },
           "embedded": {
             "color": "#cdcecf"
           },
           "emphasis": {
-            "color": "#cdcecf",
+            "color": "#bf616a",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#bf616a",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#8cafd2"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#bf616a"
+          },
+          "function.decorator": {
+            "color": "#d89079"
+          },
+          "function.kwargs": {
+            "color": "#88c0d0"
+          },
+          "function.method.constructor": {
+            "color": "#88c0d0"
+          },
+          "function.special": {
+            "color": "#bf616a"
+          },
           "keyword": {
             "color": "#b48ead"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#8cafd2"
+          },
+          "keyword.import": {
+            "color": "#d092ce"
+          },
+          "keyword.operator": {
+            "color": "#abb1bb"
+          },
+          "keyword.operator.regex": {
+            "color": "#8cafd2"
+          },
+          "label.regex": {
+            "color": "#f0d399"
           },
           "link_text": {
-            "color": "#ebcb8b",
-            "font_style": "underline"
+            "color": "#8cafd2"
           },
           "link_uri": {
-            "color": "#d89079"
+            "color": "#d89079",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#93ccdc"
           },
           "number": {
             "color": "#c9826b"
@@ -1450,11 +1653,9 @@
           "operator": {
             "color": "#abb1bb"
           },
-          "predictive": [],
           "preproc": {
             "color": "#d092ce"
           },
-          "primary": [],
           "property": {
             "color": "#81a1c1"
           },
@@ -1464,30 +1665,35 @@
           "punctuation.bracket": {
             "color": "#abb1bb"
           },
-          "punctuation.delimiter": {
-            "color": "#abb1bb"
+          "punctuation.bracket.jsx": {
+            "color": "#93ccdc"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#b48ead"
           },
           "punctuation.list_marker": {
             "color": "#93ccdc"
           },
           "punctuation.markup": {
-            "color": "#abb1bb"
+            "color": "#b48ead"
           },
           "punctuation.special": {
-            "color": "#abb1bb"
+            "color": "#93ccdc"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#ebcb8b"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#d89079"
+          },
+          "strikethrough.markup": {
+            "color": "#93ccdc"
           },
           "string": {
             "color": "#a3be8c"
           },
           "string.escape": {
-            "color": "#a3be8c"
+            "color": "#d89079"
           },
           "string.regex": {
             "color": "#f0d399"
@@ -1495,14 +1701,17 @@
           "string.special": {
             "color": "#93ccdc"
           },
-          "string.special.symbol": {
-            "color": "#bf616a"
-          },
           "tag": {
-            "color": "#9d7495"
+            "color": "#b48ead"
           },
-          "text.literal": {
-            "color": "#a3be8c"
+          "tag.component.jsx": {
+            "color": "#8cafd2"
+          },
+          "tag.doctype": {
+            "color": "#d89079"
+          },
+          "text.literal.markup": {
+            "color": "#93ccdc"
           },
           "title": {
             "color": "#8cafd2",
@@ -1511,14 +1720,20 @@
           "type": {
             "color": "#ebcb8b"
           },
+          "type.class.call": {
+            "color": "#88c0d0"
+          },
+          "type.class.inheritance": {
+            "color": "#88c0d0"
+          },
           "variable": {
+            "color": "#e5e9f0"
+          },
+          "variable.parameter": {
             "color": "#88c0d0"
           },
           "variable.special": {
             "color": "#bf616a"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#3e4a5b8C",
@@ -1710,7 +1925,12 @@
         "surface.background": "#0f1c1eFF",
         "syntax": {
           "attribute": {
-            "color": "#5a93aa"
+            "color": "#5a93aa",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#ff9664",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#ff9664"
@@ -1724,42 +1944,68 @@
           "constant": {
             "color": "#ff9664"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#ff9664"
+          },
+          "constructor": {
+            "color": "#a1cdd8"
           },
           "embedded": {
             "color": "#e6eaea"
           },
           "emphasis": {
-            "color": "#e6eaea",
+            "color": "#e85c51",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#e85c51",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#73a3b7"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#e85c51"
+          },
+          "function.decorator": {
+            "color": "#ff9664"
+          },
+          "function.kwargs": {
+            "color": "#a1cdd8"
+          },
+          "function.method.constructor": {
+            "color": "#a1cdd8"
+          },
+          "function.special": {
+            "color": "#e85c51"
+          },
           "keyword": {
             "color": "#ad5c7c"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#73a3b7"
+          },
+          "keyword.import": {
+            "color": "#d38d97"
+          },
+          "keyword.operator": {
+            "color": "#cbd9d8"
+          },
+          "keyword.operator.regex": {
+            "color": "#73a3b7"
+          },
+          "label.regex": {
+            "color": "#fdb292"
           },
           "link_text": {
-            "color": "#fda47f",
-            "font_style": "underline"
+            "color": "#73a3b7"
           },
           "link_uri": {
-            "color": "#ff9664"
+            "color": "#ff9664",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#afd4de"
           },
           "number": {
             "color": "#ff8349"
@@ -1767,11 +2013,9 @@
           "operator": {
             "color": "#cbd9d8"
           },
-          "predictive": [],
           "preproc": {
             "color": "#d38d97"
           },
-          "primary": [],
           "property": {
             "color": "#5a93aa"
           },
@@ -1781,30 +2025,35 @@
           "punctuation.bracket": {
             "color": "#cbd9d8"
           },
-          "punctuation.delimiter": {
-            "color": "#cbd9d8"
+          "punctuation.bracket.jsx": {
+            "color": "#afd4de"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#ad5c7c"
           },
           "punctuation.list_marker": {
             "color": "#afd4de"
           },
           "punctuation.markup": {
-            "color": "#cbd9d8"
+            "color": "#ad5c7c"
           },
           "punctuation.special": {
-            "color": "#cbd9d8"
+            "color": "#afd4de"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#fda47f"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#ff9664"
+          },
+          "strikethrough.markup": {
+            "color": "#afd4de"
           },
           "string": {
             "color": "#7aa4a1"
           },
           "string.escape": {
-            "color": "#7aa4a1"
+            "color": "#ff9664"
           },
           "string.regex": {
             "color": "#fdb292"
@@ -1812,14 +2061,17 @@
           "string.special": {
             "color": "#afd4de"
           },
-          "string.special.symbol": {
-            "color": "#e85c51"
-          },
           "tag": {
-            "color": "#934e69"
+            "color": "#ad5c7c"
           },
-          "text.literal": {
-            "color": "#7aa4a1"
+          "tag.component.jsx": {
+            "color": "#73a3b7"
+          },
+          "tag.doctype": {
+            "color": "#ff9664"
+          },
+          "text.literal.markup": {
+            "color": "#afd4de"
           },
           "title": {
             "color": "#73a3b7",
@@ -1828,14 +2080,20 @@
           "type": {
             "color": "#fda47f"
           },
+          "type.class.call": {
+            "color": "#a1cdd8"
+          },
+          "type.class.inheritance": {
+            "color": "#a1cdd8"
+          },
           "variable": {
+            "color": "#ebebeb"
+          },
+          "variable.parameter": {
             "color": "#a1cdd8"
           },
           "variable.special": {
             "color": "#e85c51"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#293e408C",
@@ -2027,7 +2285,12 @@
         "surface.background": "#0c0c0cFF",
         "syntax": {
           "attribute": {
-            "color": "#78a9ff"
+            "color": "#78a9ff",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#5ae0df",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#5ae0df"
@@ -2041,42 +2304,68 @@
           "constant": {
             "color": "#5ae0df"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#5ae0df"
+          },
+          "constructor": {
+            "color": "#33b1ff"
           },
           "embedded": {
             "color": "#f2f4f8"
           },
           "emphasis": {
-            "color": "#f2f4f8",
+            "color": "#ee5396",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#ee5396",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#8cb6ff"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#ee5396"
+          },
+          "function.decorator": {
+            "color": "#5ae0df"
+          },
+          "function.kwargs": {
+            "color": "#33b1ff"
+          },
+          "function.method.constructor": {
+            "color": "#33b1ff"
+          },
+          "function.special": {
+            "color": "#ee5396"
+          },
           "keyword": {
             "color": "#be95ff"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#8cb6ff"
+          },
+          "keyword.import": {
+            "color": "#ff91c1"
+          },
+          "keyword.operator": {
+            "color": "#b6b8bb"
+          },
+          "keyword.operator.regex": {
+            "color": "#8cb6ff"
+          },
+          "label.regex": {
+            "color": "#2dc7c4"
           },
           "link_text": {
-            "color": "#08bdba",
-            "font_style": "underline"
+            "color": "#8cb6ff"
           },
           "link_uri": {
-            "color": "#5ae0df"
+            "color": "#5ae0df",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#52bdff"
           },
           "number": {
             "color": "#3ddbd9"
@@ -2084,11 +2373,9 @@
           "operator": {
             "color": "#b6b8bb"
           },
-          "predictive": [],
           "preproc": {
             "color": "#ff91c1"
           },
-          "primary": [],
           "property": {
             "color": "#78a9ff"
           },
@@ -2098,30 +2385,35 @@
           "punctuation.bracket": {
             "color": "#b6b8bb"
           },
-          "punctuation.delimiter": {
-            "color": "#b6b8bb"
+          "punctuation.bracket.jsx": {
+            "color": "#52bdff"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#be95ff"
           },
           "punctuation.list_marker": {
             "color": "#52bdff"
           },
           "punctuation.markup": {
-            "color": "#b6b8bb"
+            "color": "#be95ff"
           },
           "punctuation.special": {
-            "color": "#b6b8bb"
+            "color": "#52bdff"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#08bdba"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#5ae0df"
+          },
+          "strikethrough.markup": {
+            "color": "#52bdff"
           },
           "string": {
             "color": "#25be6a"
           },
           "string.escape": {
-            "color": "#25be6a"
+            "color": "#5ae0df"
           },
           "string.regex": {
             "color": "#2dc7c4"
@@ -2129,14 +2421,17 @@
           "string.special": {
             "color": "#52bdff"
           },
-          "string.special.symbol": {
-            "color": "#ee5396"
-          },
           "tag": {
-            "color": "#a27fd9"
+            "color": "#be95ff"
           },
-          "text.literal": {
-            "color": "#25be6a"
+          "tag.component.jsx": {
+            "color": "#8cb6ff"
+          },
+          "tag.doctype": {
+            "color": "#5ae0df"
+          },
+          "text.literal.markup": {
+            "color": "#52bdff"
           },
           "title": {
             "color": "#8cb6ff",
@@ -2145,14 +2440,20 @@
           "type": {
             "color": "#08bdba"
           },
+          "type.class.call": {
+            "color": "#33b1ff"
+          },
+          "type.class.inheritance": {
+            "color": "#33b1ff"
+          },
           "variable": {
+            "color": "#dfdfe0"
+          },
+          "variable.parameter": {
             "color": "#33b1ff"
           },
           "variable.special": {
             "color": "#ee5396"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#2a2a2a8C",
@@ -2344,7 +2645,12 @@
         "surface.background": "#131a24E3",
         "syntax": {
           "attribute": {
-            "color": "#719cd6"
+            "color": "#719cd6",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#f6b079",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#f6b079"
@@ -2358,42 +2664,68 @@
           "constant": {
             "color": "#f6b079"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#f6b079"
+          },
+          "constructor": {
+            "color": "#63cdcf"
           },
           "embedded": {
             "color": "#cdcecf"
           },
           "emphasis": {
-            "color": "#cdcecf",
+            "color": "#c94f6d",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#c94f6d",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#86abdc"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#c94f6d"
+          },
+          "function.decorator": {
+            "color": "#f6b079"
+          },
+          "function.kwargs": {
+            "color": "#63cdcf"
+          },
+          "function.method.constructor": {
+            "color": "#63cdcf"
+          },
+          "function.special": {
+            "color": "#c94f6d"
+          },
           "keyword": {
             "color": "#9d79d6"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#86abdc"
+          },
+          "keyword.import": {
+            "color": "#dc8ed9"
+          },
+          "keyword.operator": {
+            "color": "#aeafb0"
+          },
+          "keyword.operator.regex": {
+            "color": "#86abdc"
+          },
+          "label.regex": {
+            "color": "#e0c989"
           },
           "link_text": {
-            "color": "#dbc074",
-            "font_style": "underline"
+            "color": "#86abdc"
           },
           "link_uri": {
-            "color": "#f6b079"
+            "color": "#f6b079",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#7ad5d6"
           },
           "number": {
             "color": "#f4a261"
@@ -2401,11 +2733,9 @@
           "operator": {
             "color": "#aeafb0"
           },
-          "predictive": [],
           "preproc": {
             "color": "#dc8ed9"
           },
-          "primary": [],
           "property": {
             "color": "#719cd6"
           },
@@ -2415,30 +2745,35 @@
           "punctuation.bracket": {
             "color": "#aeafb0"
           },
-          "punctuation.delimiter": {
-            "color": "#aeafb0"
+          "punctuation.bracket.jsx": {
+            "color": "#7ad5d6"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#9d79d6"
           },
           "punctuation.list_marker": {
             "color": "#7ad5d6"
           },
           "punctuation.markup": {
-            "color": "#aeafb0"
+            "color": "#9d79d6"
           },
           "punctuation.special": {
-            "color": "#aeafb0"
+            "color": "#7ad5d6"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#dbc074"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#f6b079"
+          },
+          "strikethrough.markup": {
+            "color": "#7ad5d6"
           },
           "string": {
             "color": "#81b29a"
           },
           "string.escape": {
-            "color": "#81b29a"
+            "color": "#f6b079"
           },
           "string.regex": {
             "color": "#e0c989"
@@ -2446,14 +2781,17 @@
           "string.special": {
             "color": "#7ad5d6"
           },
-          "string.special.symbol": {
-            "color": "#c94f6d"
-          },
           "tag": {
-            "color": "#8567b6"
+            "color": "#9d79d6"
           },
-          "text.literal": {
-            "color": "#81b29a"
+          "tag.component.jsx": {
+            "color": "#86abdc"
+          },
+          "tag.doctype": {
+            "color": "#f6b079"
+          },
+          "text.literal.markup": {
+            "color": "#7ad5d6"
           },
           "title": {
             "color": "#86abdc",
@@ -2462,14 +2800,20 @@
           "type": {
             "color": "#dbc074"
           },
+          "type.class.call": {
+            "color": "#63cdcf"
+          },
+          "type.class.inheritance": {
+            "color": "#63cdcf"
+          },
           "variable": {
+            "color": "#dfdfe0"
+          },
+          "variable.parameter": {
             "color": "#63cdcf"
           },
           "variable.special": {
             "color": "#c94f6d"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#2b3b5157",
@@ -2661,7 +3005,12 @@
         "surface.background": "#e4dcd4E3",
         "syntax": {
           "attribute": {
-            "color": "#2848a9"
+            "color": "#2848a9",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#7f5152",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#7f5152"
@@ -2675,42 +3024,68 @@
           "constant": {
             "color": "#7f5152"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#7f5152"
+          },
+          "constructor": {
+            "color": "#287980"
           },
           "embedded": {
             "color": "#3d2b5a"
           },
           "emphasis": {
-            "color": "#3d2b5a",
+            "color": "#a5222f",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#a5222f",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#223d90"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#a5222f"
+          },
+          "function.decorator": {
+            "color": "#7f5152"
+          },
+          "function.kwargs": {
+            "color": "#287980"
+          },
+          "function.method.constructor": {
+            "color": "#287980"
+          },
+          "function.special": {
+            "color": "#a5222f"
+          },
           "keyword": {
             "color": "#6e33ce"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#223d90"
+          },
+          "keyword.import": {
+            "color": "#8b369a"
+          },
+          "keyword.operator": {
+            "color": "#643f61"
+          },
+          "keyword.operator.regex": {
+            "color": "#223d90"
+          },
+          "label.regex": {
+            "color": "#924702"
           },
           "link_text": {
-            "color": "#ac5402",
-            "font_style": "underline"
+            "color": "#223d90"
           },
           "link_uri": {
-            "color": "#7f5152"
+            "color": "#7f5152",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#22676d"
           },
           "number": {
             "color": "#955f61"
@@ -2718,11 +3093,9 @@
           "operator": {
             "color": "#643f61"
           },
-          "predictive": [],
           "preproc": {
             "color": "#8b369a"
           },
-          "primary": [],
           "property": {
             "color": "#2848a9"
           },
@@ -2732,30 +3105,35 @@
           "punctuation.bracket": {
             "color": "#643f61"
           },
-          "punctuation.delimiter": {
-            "color": "#643f61"
+          "punctuation.bracket.jsx": {
+            "color": "#22676d"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#6e33ce"
           },
           "punctuation.list_marker": {
             "color": "#22676d"
           },
           "punctuation.markup": {
-            "color": "#643f61"
+            "color": "#6e33ce"
           },
           "punctuation.special": {
-            "color": "#643f61"
+            "color": "#22676d"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#ac5402"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#7f5152"
+          },
+          "strikethrough.markup": {
+            "color": "#22676d"
           },
           "string": {
             "color": "#396847"
           },
           "string.escape": {
-            "color": "#396847"
+            "color": "#7f5152"
           },
           "string.regex": {
             "color": "#924702"
@@ -2763,14 +3141,17 @@
           "string.special": {
             "color": "#22676d"
           },
-          "string.special.symbol": {
-            "color": "#a5222f"
-          },
           "tag": {
-            "color": "#5e2baf"
+            "color": "#6e33ce"
           },
-          "text.literal": {
-            "color": "#396847"
+          "tag.component.jsx": {
+            "color": "#223d90"
+          },
+          "tag.doctype": {
+            "color": "#7f5152"
+          },
+          "text.literal.markup": {
+            "color": "#22676d"
           },
           "title": {
             "color": "#223d90",
@@ -2779,14 +3160,20 @@
           "type": {
             "color": "#ac5402"
           },
+          "type.class.call": {
+            "color": "#287980"
+          },
+          "type.class.inheritance": {
+            "color": "#287980"
+          },
           "variable": {
+            "color": "#352c24"
+          },
+          "variable.parameter": {
             "color": "#287980"
           },
           "variable.special": {
             "color": "#a5222f"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#e7d2be57",
@@ -2978,7 +3365,12 @@
         "surface.background": "#ebe5dfE3",
         "syntax": {
           "attribute": {
-            "color": "#286983"
+            "color": "#286983",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#ca6e69",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#ca6e69"
@@ -2992,42 +3384,68 @@
           "constant": {
             "color": "#ca6e69"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#ca6e69"
+          },
+          "constructor": {
+            "color": "#56949f"
           },
           "embedded": {
             "color": "#575279"
           },
           "emphasis": {
-            "color": "#575279",
+            "color": "#b4637a",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#b4637a",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#295e73"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#b4637a"
+          },
+          "function.decorator": {
+            "color": "#ca6e69"
+          },
+          "function.kwargs": {
+            "color": "#56949f"
+          },
+          "function.method.constructor": {
+            "color": "#56949f"
+          },
+          "function.special": {
+            "color": "#b4637a"
+          },
           "keyword": {
             "color": "#907aa9"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#295e73"
+          },
+          "keyword.import": {
+            "color": "#c9709e"
+          },
+          "keyword.operator": {
+            "color": "#625c87"
+          },
+          "keyword.operator.regex": {
+            "color": "#295e73"
+          },
+          "label.regex": {
+            "color": "#dd9024"
           },
           "link_text": {
-            "color": "#ea9d34",
-            "font_style": "underline"
+            "color": "#295e73"
           },
           "link_uri": {
-            "color": "#ca6e69"
+            "color": "#ca6e69",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#50848c"
           },
           "number": {
             "color": "#d7827e"
@@ -3035,11 +3453,9 @@
           "operator": {
             "color": "#625c87"
           },
-          "predictive": [],
           "preproc": {
             "color": "#c9709e"
           },
-          "primary": [],
           "property": {
             "color": "#286983"
           },
@@ -3049,30 +3465,35 @@
           "punctuation.bracket": {
             "color": "#625c87"
           },
-          "punctuation.delimiter": {
-            "color": "#625c87"
+          "punctuation.bracket.jsx": {
+            "color": "#50848c"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#907aa9"
           },
           "punctuation.list_marker": {
             "color": "#50848c"
           },
           "punctuation.markup": {
-            "color": "#625c87"
+            "color": "#907aa9"
           },
           "punctuation.special": {
-            "color": "#625c87"
+            "color": "#50848c"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#ea9d34"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#ca6e69"
+          },
+          "strikethrough.markup": {
+            "color": "#50848c"
           },
           "string": {
             "color": "#618774"
           },
           "string.escape": {
-            "color": "#618774"
+            "color": "#ca6e69"
           },
           "string.regex": {
             "color": "#dd9024"
@@ -3080,14 +3501,17 @@
           "string.special": {
             "color": "#50848c"
           },
-          "string.special.symbol": {
-            "color": "#b4637a"
-          },
           "tag": {
-            "color": "#816b9a"
+            "color": "#907aa9"
           },
-          "text.literal": {
-            "color": "#618774"
+          "tag.component.jsx": {
+            "color": "#295e73"
+          },
+          "tag.doctype": {
+            "color": "#ca6e69"
+          },
+          "text.literal.markup": {
+            "color": "#50848c"
           },
           "title": {
             "color": "#295e73",
@@ -3096,14 +3520,20 @@
           "type": {
             "color": "#ea9d34"
           },
+          "type.class.call": {
+            "color": "#56949f"
+          },
+          "type.class.inheritance": {
+            "color": "#56949f"
+          },
           "variable": {
+            "color": "#575279"
+          },
+          "variable.parameter": {
             "color": "#56949f"
           },
           "variable.special": {
             "color": "#b4637a"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#d0d8d857",
@@ -3295,7 +3725,12 @@
         "surface.background": "#191726E3",
         "syntax": {
           "attribute": {
-            "color": "#569fba"
+            "color": "#569fba",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#f0a4a2",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#f0a4a2"
@@ -3309,42 +3744,68 @@
           "constant": {
             "color": "#f0a4a2"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#f0a4a2"
+          },
+          "constructor": {
+            "color": "#9ccfd8"
           },
           "embedded": {
             "color": "#e0def4"
           },
           "emphasis": {
-            "color": "#e0def4",
+            "color": "#eb6f92",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#eb6f92",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#65b1cd"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#eb6f92"
+          },
+          "function.decorator": {
+            "color": "#f0a4a2"
+          },
+          "function.kwargs": {
+            "color": "#9ccfd8"
+          },
+          "function.method.constructor": {
+            "color": "#9ccfd8"
+          },
+          "function.special": {
+            "color": "#eb6f92"
+          },
           "keyword": {
             "color": "#c4a7e7"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#65b1cd"
+          },
+          "keyword.import": {
+            "color": "#f0a6cc"
+          },
+          "keyword.operator": {
+            "color": "#cdcbe0"
+          },
+          "keyword.operator.regex": {
+            "color": "#65b1cd"
+          },
+          "label.regex": {
+            "color": "#f9cb8c"
           },
           "link_text": {
-            "color": "#f6c177",
-            "font_style": "underline"
+            "color": "#65b1cd"
           },
           "link_uri": {
-            "color": "#f0a4a2"
+            "color": "#f0a4a2",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#a6dae3"
           },
           "number": {
             "color": "#ea9a97"
@@ -3352,11 +3813,9 @@
           "operator": {
             "color": "#cdcbe0"
           },
-          "predictive": [],
           "preproc": {
             "color": "#f0a6cc"
           },
-          "primary": [],
           "property": {
             "color": "#569fba"
           },
@@ -3366,30 +3825,35 @@
           "punctuation.bracket": {
             "color": "#cdcbe0"
           },
-          "punctuation.delimiter": {
-            "color": "#cdcbe0"
+          "punctuation.bracket.jsx": {
+            "color": "#a6dae3"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#c4a7e7"
           },
           "punctuation.list_marker": {
             "color": "#a6dae3"
           },
           "punctuation.markup": {
-            "color": "#cdcbe0"
+            "color": "#c4a7e7"
           },
           "punctuation.special": {
-            "color": "#cdcbe0"
+            "color": "#a6dae3"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#f6c177"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#f0a4a2"
+          },
+          "strikethrough.markup": {
+            "color": "#a6dae3"
           },
           "string": {
             "color": "#a3be8c"
           },
           "string.escape": {
-            "color": "#a3be8c"
+            "color": "#f0a4a2"
           },
           "string.regex": {
             "color": "#f9cb8c"
@@ -3397,14 +3861,17 @@
           "string.special": {
             "color": "#a6dae3"
           },
-          "string.special.symbol": {
-            "color": "#eb6f92"
-          },
           "tag": {
-            "color": "#a580d2"
+            "color": "#c4a7e7"
           },
-          "text.literal": {
-            "color": "#a3be8c"
+          "tag.component.jsx": {
+            "color": "#65b1cd"
+          },
+          "tag.doctype": {
+            "color": "#f0a4a2"
+          },
+          "text.literal.markup": {
+            "color": "#a6dae3"
           },
           "title": {
             "color": "#65b1cd",
@@ -3413,14 +3880,20 @@
           "type": {
             "color": "#f6c177"
           },
+          "type.class.call": {
+            "color": "#9ccfd8"
+          },
+          "type.class.inheritance": {
+            "color": "#9ccfd8"
+          },
           "variable": {
+            "color": "#e0def4"
+          },
+          "variable.parameter": {
             "color": "#9ccfd8"
           },
           "variable.special": {
             "color": "#eb6f92"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#433c5957",
@@ -3612,7 +4085,12 @@
         "surface.background": "#232831E3",
         "syntax": {
           "attribute": {
-            "color": "#81a1c1"
+            "color": "#81a1c1",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#d89079",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#d89079"
@@ -3626,42 +4104,68 @@
           "constant": {
             "color": "#d89079"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#d89079"
+          },
+          "constructor": {
+            "color": "#88c0d0"
           },
           "embedded": {
             "color": "#cdcecf"
           },
           "emphasis": {
-            "color": "#cdcecf",
+            "color": "#bf616a",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#bf616a",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#8cafd2"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#bf616a"
+          },
+          "function.decorator": {
+            "color": "#d89079"
+          },
+          "function.kwargs": {
+            "color": "#88c0d0"
+          },
+          "function.method.constructor": {
+            "color": "#88c0d0"
+          },
+          "function.special": {
+            "color": "#bf616a"
+          },
           "keyword": {
             "color": "#b48ead"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#8cafd2"
+          },
+          "keyword.import": {
+            "color": "#d092ce"
+          },
+          "keyword.operator": {
+            "color": "#abb1bb"
+          },
+          "keyword.operator.regex": {
+            "color": "#8cafd2"
+          },
+          "label.regex": {
+            "color": "#f0d399"
           },
           "link_text": {
-            "color": "#ebcb8b",
-            "font_style": "underline"
+            "color": "#8cafd2"
           },
           "link_uri": {
-            "color": "#d89079"
+            "color": "#d89079",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#93ccdc"
           },
           "number": {
             "color": "#c9826b"
@@ -3669,11 +4173,9 @@
           "operator": {
             "color": "#abb1bb"
           },
-          "predictive": [],
           "preproc": {
             "color": "#d092ce"
           },
-          "primary": [],
           "property": {
             "color": "#81a1c1"
           },
@@ -3683,30 +4185,35 @@
           "punctuation.bracket": {
             "color": "#abb1bb"
           },
-          "punctuation.delimiter": {
-            "color": "#abb1bb"
+          "punctuation.bracket.jsx": {
+            "color": "#93ccdc"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#b48ead"
           },
           "punctuation.list_marker": {
             "color": "#93ccdc"
           },
           "punctuation.markup": {
-            "color": "#abb1bb"
+            "color": "#b48ead"
           },
           "punctuation.special": {
-            "color": "#abb1bb"
+            "color": "#93ccdc"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#ebcb8b"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#d89079"
+          },
+          "strikethrough.markup": {
+            "color": "#93ccdc"
           },
           "string": {
             "color": "#a3be8c"
           },
           "string.escape": {
-            "color": "#a3be8c"
+            "color": "#d89079"
           },
           "string.regex": {
             "color": "#f0d399"
@@ -3714,14 +4221,17 @@
           "string.special": {
             "color": "#93ccdc"
           },
-          "string.special.symbol": {
-            "color": "#bf616a"
-          },
           "tag": {
-            "color": "#9d7495"
+            "color": "#b48ead"
           },
-          "text.literal": {
-            "color": "#a3be8c"
+          "tag.component.jsx": {
+            "color": "#8cafd2"
+          },
+          "tag.doctype": {
+            "color": "#d89079"
+          },
+          "text.literal.markup": {
+            "color": "#93ccdc"
           },
           "title": {
             "color": "#8cafd2",
@@ -3730,14 +4240,20 @@
           "type": {
             "color": "#ebcb8b"
           },
+          "type.class.call": {
+            "color": "#88c0d0"
+          },
+          "type.class.inheritance": {
+            "color": "#88c0d0"
+          },
           "variable": {
+            "color": "#e5e9f0"
+          },
+          "variable.parameter": {
             "color": "#88c0d0"
           },
           "variable.special": {
             "color": "#bf616a"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#3e4a5b57",
@@ -3929,7 +4445,12 @@
         "surface.background": "#0f1c1eE3",
         "syntax": {
           "attribute": {
-            "color": "#5a93aa"
+            "color": "#5a93aa",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#ff9664",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#ff9664"
@@ -3943,42 +4464,68 @@
           "constant": {
             "color": "#ff9664"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#ff9664"
+          },
+          "constructor": {
+            "color": "#a1cdd8"
           },
           "embedded": {
             "color": "#e6eaea"
           },
           "emphasis": {
-            "color": "#e6eaea",
+            "color": "#e85c51",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#e85c51",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#73a3b7"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#e85c51"
+          },
+          "function.decorator": {
+            "color": "#ff9664"
+          },
+          "function.kwargs": {
+            "color": "#a1cdd8"
+          },
+          "function.method.constructor": {
+            "color": "#a1cdd8"
+          },
+          "function.special": {
+            "color": "#e85c51"
+          },
           "keyword": {
             "color": "#ad5c7c"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#73a3b7"
+          },
+          "keyword.import": {
+            "color": "#d38d97"
+          },
+          "keyword.operator": {
+            "color": "#cbd9d8"
+          },
+          "keyword.operator.regex": {
+            "color": "#73a3b7"
+          },
+          "label.regex": {
+            "color": "#fdb292"
           },
           "link_text": {
-            "color": "#fda47f",
-            "font_style": "underline"
+            "color": "#73a3b7"
           },
           "link_uri": {
-            "color": "#ff9664"
+            "color": "#ff9664",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#afd4de"
           },
           "number": {
             "color": "#ff8349"
@@ -3986,11 +4533,9 @@
           "operator": {
             "color": "#cbd9d8"
           },
-          "predictive": [],
           "preproc": {
             "color": "#d38d97"
           },
-          "primary": [],
           "property": {
             "color": "#5a93aa"
           },
@@ -4000,30 +4545,35 @@
           "punctuation.bracket": {
             "color": "#cbd9d8"
           },
-          "punctuation.delimiter": {
-            "color": "#cbd9d8"
+          "punctuation.bracket.jsx": {
+            "color": "#afd4de"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#ad5c7c"
           },
           "punctuation.list_marker": {
             "color": "#afd4de"
           },
           "punctuation.markup": {
-            "color": "#cbd9d8"
+            "color": "#ad5c7c"
           },
           "punctuation.special": {
-            "color": "#cbd9d8"
+            "color": "#afd4de"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#fda47f"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#ff9664"
+          },
+          "strikethrough.markup": {
+            "color": "#afd4de"
           },
           "string": {
             "color": "#7aa4a1"
           },
           "string.escape": {
-            "color": "#7aa4a1"
+            "color": "#ff9664"
           },
           "string.regex": {
             "color": "#fdb292"
@@ -4031,14 +4581,17 @@
           "string.special": {
             "color": "#afd4de"
           },
-          "string.special.symbol": {
-            "color": "#e85c51"
-          },
           "tag": {
-            "color": "#934e69"
+            "color": "#ad5c7c"
           },
-          "text.literal": {
-            "color": "#7aa4a1"
+          "tag.component.jsx": {
+            "color": "#73a3b7"
+          },
+          "tag.doctype": {
+            "color": "#ff9664"
+          },
+          "text.literal.markup": {
+            "color": "#afd4de"
           },
           "title": {
             "color": "#73a3b7",
@@ -4047,14 +4600,20 @@
           "type": {
             "color": "#fda47f"
           },
+          "type.class.call": {
+            "color": "#a1cdd8"
+          },
+          "type.class.inheritance": {
+            "color": "#a1cdd8"
+          },
           "variable": {
+            "color": "#ebebeb"
+          },
+          "variable.parameter": {
             "color": "#a1cdd8"
           },
           "variable.special": {
             "color": "#e85c51"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#293e4057",
@@ -4246,7 +4805,12 @@
         "surface.background": "#0c0c0cE3",
         "syntax": {
           "attribute": {
-            "color": "#78a9ff"
+            "color": "#78a9ff",
+            "font_style": "italic"
+          },
+          "attribute.builtin": {
+            "color": "#5ae0df",
+            "font_style": "normal"
           },
           "boolean": {
             "color": "#5ae0df"
@@ -4260,42 +4824,68 @@
           "constant": {
             "color": "#5ae0df"
           },
-          "constructor": {
+          "constant.builtin": {
             "color": "#5ae0df"
+          },
+          "constructor": {
+            "color": "#33b1ff"
           },
           "embedded": {
             "color": "#f2f4f8"
           },
           "emphasis": {
-            "color": "#f2f4f8",
+            "color": "#ee5396",
             "font_style": "italic"
           },
           "emphasis.strong": {
             "color": "#ee5396",
             "font_weight": 700
           },
-          "enum": {
-            "color": "#dd0000"
-          },
           "function": {
             "color": "#8cb6ff"
           },
-          "hint": [],
+          "function.builtin": {
+            "color": "#ee5396"
+          },
+          "function.decorator": {
+            "color": "#5ae0df"
+          },
+          "function.kwargs": {
+            "color": "#33b1ff"
+          },
+          "function.method.constructor": {
+            "color": "#33b1ff"
+          },
+          "function.special": {
+            "color": "#ee5396"
+          },
           "keyword": {
             "color": "#be95ff"
           },
-          "label": {
-            "color": "#dd00dd"
+          "keyword.directive": {
+            "color": "#8cb6ff"
+          },
+          "keyword.import": {
+            "color": "#ff91c1"
+          },
+          "keyword.operator": {
+            "color": "#b6b8bb"
+          },
+          "keyword.operator.regex": {
+            "color": "#8cb6ff"
+          },
+          "label.regex": {
+            "color": "#2dc7c4"
           },
           "link_text": {
-            "color": "#08bdba",
-            "font_style": "underline"
+            "color": "#8cb6ff"
           },
           "link_uri": {
-            "color": "#5ae0df"
+            "color": "#5ae0df",
+            "font_style": "italic"
           },
           "namespace": {
-            "color": "#0000dd"
+            "color": "#52bdff"
           },
           "number": {
             "color": "#3ddbd9"
@@ -4303,11 +4893,9 @@
           "operator": {
             "color": "#b6b8bb"
           },
-          "predictive": [],
           "preproc": {
             "color": "#ff91c1"
           },
-          "primary": [],
           "property": {
             "color": "#78a9ff"
           },
@@ -4317,30 +4905,35 @@
           "punctuation.bracket": {
             "color": "#b6b8bb"
           },
-          "punctuation.delimiter": {
-            "color": "#b6b8bb"
+          "punctuation.bracket.jsx": {
+            "color": "#52bdff"
+          },
+          "punctuation.embedded.markup": {
+            "color": "#be95ff"
           },
           "punctuation.list_marker": {
             "color": "#52bdff"
           },
           "punctuation.markup": {
-            "color": "#b6b8bb"
+            "color": "#be95ff"
           },
           "punctuation.special": {
-            "color": "#b6b8bb"
+            "color": "#52bdff"
           },
           "selector": {
-            "color": "#00dddd"
+            "color": "#08bdba"
           },
           "selector.pseudo": {
-            "color": "#00dddd",
-            "font_style": "italic"
+            "color": "#5ae0df"
+          },
+          "strikethrough.markup": {
+            "color": "#52bdff"
           },
           "string": {
             "color": "#25be6a"
           },
           "string.escape": {
-            "color": "#25be6a"
+            "color": "#5ae0df"
           },
           "string.regex": {
             "color": "#2dc7c4"
@@ -4348,14 +4941,17 @@
           "string.special": {
             "color": "#52bdff"
           },
-          "string.special.symbol": {
-            "color": "#ee5396"
-          },
           "tag": {
-            "color": "#a27fd9"
+            "color": "#be95ff"
           },
-          "text.literal": {
-            "color": "#25be6a"
+          "tag.component.jsx": {
+            "color": "#8cb6ff"
+          },
+          "tag.doctype": {
+            "color": "#5ae0df"
+          },
+          "text.literal.markup": {
+            "color": "#52bdff"
           },
           "title": {
             "color": "#8cb6ff",
@@ -4364,14 +4960,20 @@
           "type": {
             "color": "#08bdba"
           },
+          "type.class.call": {
+            "color": "#33b1ff"
+          },
+          "type.class.inheritance": {
+            "color": "#33b1ff"
+          },
           "variable": {
+            "color": "#dfdfe0"
+          },
+          "variable.parameter": {
             "color": "#33b1ff"
           },
           "variable.special": {
             "color": "#ee5396"
-          },
-          "variant": {
-            "color": "#00dd00"
           }
         },
         "tab.active_background": "#2a2a2a57",


### PR DESCRIPTION
This change improves the general syntax highlighting of all supported [Tree-Sitter queries] syntax keys, as well as those specific to a particular [language grammar]. 
Besides the better language supports, it aims to bring the theme closer to the original Neovim theme.

### Main Improvements

| Markdown | Improve link highlighting as in Neovim |
|:-:|-|
| before | <img width="689" height="87" alt="link-before" src="https://github.com/user-attachments/assets/840ab67f-0c51-48cb-bf21-718e863010eb" />|
| after | <img width="689" height="87" alt="link-after" src="https://github.com/user-attachments/assets/c84caff5-5cc9-46e3-b83f-8cc224cb08a1" />|
| Neovim | <img width="689" height="87" alt="link-nvim" src="https://github.com/user-attachments/assets/240978ad-5d22-4c3b-a992-069598acbd09" />|

**Markup** Improve attribute highlighting as in Neovim
| Before | After | Neovim |
| :-: | - | - |
| <img width="313" height="86" alt="tag-doctype-before" src="https://github.com/user-attachments/assets/7b66c422-16b2-46d7-a3a2-d2e0867abeb6" /> | <img width="313" height="86" alt="tag-doctype-after" src="https://github.com/user-attachments/assets/d114fd0d-853f-45fa-b2bd-3fc3468e6bf3" /> | <img width="313" height="86" alt="tag-doctype-nvim" src="https://github.com/user-attachments/assets/96defd57-5bf2-4cbd-a687-5a56ed83e1b9" /> |

**CSS** Align selector highlighting with Neovim
| Before | After | Neovim |
| :-: | - | - |
| <img width="313" height="189" alt="selector-before" src="https://github.com/user-attachments/assets/37c60d21-995c-4a2e-ad19-1a0a3cc06d40" /> | <img width="313" height="189" alt="selector-after" src="https://github.com/user-attachments/assets/08d56446-085e-40fc-bb5f-b4e064826f21" /> | <img width="313" height="189" alt="selector-nvim" src="https://github.com/user-attachments/assets/0596c4ee-144e-4961-bc4e-23b28b876896" /> |

### Minor Improvements

- better regex support
- better JSX support
- improves python support
  - relates to #50 
  
[Tree-Sitter queries]: https://zed.dev/docs/extensions/languages#syntax-highlightingas
[language grammar]: https://github.com/zed-industries/zed/tree/main/crates/grammars/src
