### PR TITLE
fix(#58): update git conflict marker colors

### DIFF
--- a/lib/theme.lua
+++ b/lib/theme.lua
@@ -221,8 +221,8 @@ function M._theme_colors(pal, spec, background_appearance)
     ["version_control.renamed"] = spec.git.changed,
     ["version_control.conflict"] = spec.git.conflict,
     ["version_control.ignored"] = spec.git.ignored,
-    ["version_control.conflict_marker.ours"] = todo.blue.base,
-    ["version_control.conflict_marker.theirs"] = todo.yellow.base,
+    ["version_control.conflict_marker.ours"] = alpha(pal.magenta.bright, a.LOW),
+    ["version_control.conflict_marker.theirs"] = alpha(pal.cyan.bright, a.LOW),
     -- Terminal
     ["terminal.background"] = alpha(spec.bg1, a.MAX_POLARIZE),
     ["terminal.foreground"] = spec.fg1,


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="509" height="134" alt="issue-58-before" src="https://github.com/user-attachments/assets/fe210392-b6fc-435c-b4d5-9f390518154a" />|<img width="509" height="134" alt="issue-58-after" src="https://github.com/user-attachments/assets/e14d0d3e-6c9b-41e3-b3ba-d4952bcb93fa" />|

fixes #58